### PR TITLE
[FEAT] 이미지 업로드 API를 구현한다.

### DIFF
--- a/src/main/java/indipage/org/indipage/api/image/controller/ImageController.java
+++ b/src/main/java/indipage/org/indipage/api/image/controller/ImageController.java
@@ -1,0 +1,34 @@
+package indipage.org.indipage.api.image.controller;
+
+import indipage.org.indipage.api.image.controller.dto.request.ImageRequestDto;
+import indipage.org.indipage.api.image.controller.dto.response.ImageCreatedResponseDto;
+import indipage.org.indipage.common.dto.ApiResponse;
+import indipage.org.indipage.exception.Success;
+import indipage.org.indipage.external.client.aws.S3Service;
+import javax.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/image")
+public class ImageController {
+
+    private final S3Service s3Service;
+
+    @PostMapping(value = "/single", consumes = MediaType.MULTIPART_FORM_DATA_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
+    @ResponseStatus(HttpStatus.CREATED)
+    public ApiResponse create(
+            @ModelAttribute @Valid final ImageRequestDto request) {
+
+        String imageUrl = s3Service.uploadIamge(request.getImage(), request.getFolder());
+        return ApiResponse.success(Success.CREATE_IMAGE_SUCCESS, ImageCreatedResponseDto.of(imageUrl));
+    }
+
+}

--- a/src/main/java/indipage/org/indipage/api/image/controller/dto/request/ImageRequestDto.java
+++ b/src/main/java/indipage/org/indipage/api/image/controller/dto/request/ImageRequestDto.java
@@ -11,7 +11,7 @@ import org.springframework.web.multipart.MultipartFile;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
-@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@AllArgsConstructor
 public class ImageRequestDto {
     @NotNull
     private MultipartFile image;

--- a/src/main/java/indipage/org/indipage/api/image/controller/dto/request/ImageRequestDto.java
+++ b/src/main/java/indipage/org/indipage/api/image/controller/dto/request/ImageRequestDto.java
@@ -1,0 +1,22 @@
+package indipage.org.indipage.api.image.controller.dto.request;
+
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Pattern;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.web.multipart.MultipartFile;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class ImageRequestDto {
+    @NotNull
+    private MultipartFile image;
+
+    @NotBlank
+    @Pattern(regexp = "(^book$)|(^bookstore$)", message = "지원하지 않는 폴더입니다")
+    private String folder;
+}

--- a/src/main/java/indipage/org/indipage/api/image/controller/dto/response/ImageCreatedResponseDto.java
+++ b/src/main/java/indipage/org/indipage/api/image/controller/dto/response/ImageCreatedResponseDto.java
@@ -1,0 +1,17 @@
+package indipage.org.indipage.api.image.controller.dto.response;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class ImageCreatedResponseDto {
+    private String imageUrl;
+
+    public static ImageCreatedResponseDto of(String imageUrl) {
+        return new ImageCreatedResponseDto(imageUrl);
+    }
+}

--- a/src/main/java/indipage/org/indipage/common/advice/ControllerExceptionAdvice.java
+++ b/src/main/java/indipage/org/indipage/common/advice/ControllerExceptionAdvice.java
@@ -5,6 +5,9 @@ import indipage.org.indipage.common.dto.ApiResponse;
 import indipage.org.indipage.exception.Error;
 import indipage.org.indipage.exception.model.CustomException;
 import java.util.Objects;
+import lombok.extern.slf4j.Slf4j;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.BindException;
@@ -13,8 +16,11 @@ import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
+@Slf4j
 @RestControllerAdvice
 public class ControllerExceptionAdvice {
+
+    private final Logger logger = LoggerFactory.getLogger(ControllerExceptionAdvice.class);
 
     /**
      * 400 BAD_REQUEST
@@ -33,7 +39,7 @@ public class ControllerExceptionAdvice {
     @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
     @ExceptionHandler(Exception.class)
     protected ApiResponse<Object> handleException(final Exception e) {
-        System.out.println(e.getClass() + ": " + e.getMessage());
+        logger.error("{} : {}", e.getClass(), e.getMessage());
         return ApiResponse.error(Error.INTERNAL_SERVER_ERROR);
     }
 

--- a/src/main/java/indipage/org/indipage/common/advice/ControllerExceptionAdvice.java
+++ b/src/main/java/indipage/org/indipage/common/advice/ControllerExceptionAdvice.java
@@ -15,6 +15,7 @@ import org.springframework.validation.FieldError;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.multipart.MaxUploadSizeExceededException;
 
 @Slf4j
 @RestControllerAdvice
@@ -31,6 +32,16 @@ public class ControllerExceptionAdvice {
         FieldError fieldError = Objects.requireNonNull(e.getFieldError());
         return ApiResponse.error(Error.REQUEST_VALIDATION_EXCEPTION,
                 String.format("%s는 %s", fieldError.getField(), fieldError.getDefaultMessage()));
+    }
+
+    /**
+     * 413 PAYLOAD_TOO_LARGE
+     */
+    @ExceptionHandler(MaxUploadSizeExceededException.class)
+    @ResponseStatus(HttpStatus.PAYLOAD_TOO_LARGE)
+    public ApiResponse fileSizeLimitExceeded(final MaxUploadSizeExceededException e) {
+        return ApiResponse.error(Error.IMAGE_TOO_LARGE_EXCEPTION,
+                String.format(Error.IMAGE_TOO_LARGE_EXCEPTION.getMessage()));
     }
 
     /**

--- a/src/main/java/indipage/org/indipage/common/advice/ControllerExceptionAdvice.java
+++ b/src/main/java/indipage/org/indipage/common/advice/ControllerExceptionAdvice.java
@@ -7,8 +7,8 @@ import indipage.org.indipage.exception.model.CustomException;
 import java.util.Objects;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.BindException;
 import org.springframework.validation.FieldError;
-import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
@@ -20,8 +20,8 @@ public class ControllerExceptionAdvice {
      * 400 BAD_REQUEST
      */
     @ResponseStatus(HttpStatus.BAD_REQUEST)
-    @ExceptionHandler(MethodArgumentNotValidException.class)
-    protected ApiResponse handleMethodArgumentNotValidException(final MethodArgumentNotValidException e) {
+    @ExceptionHandler(BindException.class)
+    protected ApiResponse handleBindException(final BindException e) {
         FieldError fieldError = Objects.requireNonNull(e.getFieldError());
         return ApiResponse.error(Error.REQUEST_VALIDATION_EXCEPTION,
                 String.format("%s는 %s", fieldError.getField(), fieldError.getDefaultMessage()));
@@ -33,7 +33,7 @@ public class ControllerExceptionAdvice {
     @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
     @ExceptionHandler(Exception.class)
     protected ApiResponse<Object> handleException(final Exception e) {
-        System.out.println(e.getMessage());
+        System.out.println(e.getClass() + ": " + e.getMessage());
         return ApiResponse.error(Error.INTERNAL_SERVER_ERROR);
     }
 

--- a/src/main/java/indipage/org/indipage/exception/Error.java
+++ b/src/main/java/indipage/org/indipage/exception/Error.java
@@ -27,7 +27,10 @@ public enum Error {
      * 409 CONFLICT
      */
 
-
+    /**
+     * 413 PAYLOAD_TOO_LARGE
+     */
+    IMAGE_TOO_LARGE_EXCEPTION(HttpStatus.PAYLOAD_TOO_LARGE, "업로드 가능한 이미지 최대 용량은 3MB입니다."),
     /**
      * 500 INTERNAL SERVER ERROR
      */

--- a/src/main/java/indipage/org/indipage/exception/Error.java
+++ b/src/main/java/indipage/org/indipage/exception/Error.java
@@ -13,7 +13,7 @@ public enum Error {
      * 400 BAD REQUEST
      */
     REQUEST_VALIDATION_EXCEPTION(HttpStatus.BAD_REQUEST, "잘못된 요청입니다"),
-
+    INVALID_MULTIPART_EXTENSION_EXCEPTION(HttpStatus.BAD_REQUEST, "지원하지 않는 이미지 형식입니다"),
     /**
      * 401 UNAUTHORIZED
      */
@@ -21,7 +21,8 @@ public enum Error {
     /**
      * 404 NOT FOUND
      */
-
+    NOT_FOUND_IMAGE_EXCEPTION(HttpStatus.NOT_FOUND, "이미지가 입력되지 않았습니다"),
+    NOT_FOUND_SAVED_IMAGE_EXCEPTION(HttpStatus.NOT_FOUND, "저장된 이미지가 없습니다"),
     /**
      * 409 CONFLICT
      */

--- a/src/main/java/indipage/org/indipage/exception/Error.java
+++ b/src/main/java/indipage/org/indipage/exception/Error.java
@@ -21,8 +21,7 @@ public enum Error {
     /**
      * 404 NOT FOUND
      */
-    NOT_FOUND_IMAGE_EXCEPTION(HttpStatus.NOT_FOUND, "이미지가 입력되지 않았습니다"),
-    NOT_FOUND_SAVED_IMAGE_EXCEPTION(HttpStatus.NOT_FOUND, "저장된 이미지가 없습니다"),
+
     /**
      * 409 CONFLICT
      */
@@ -34,6 +33,8 @@ public enum Error {
     /**
      * 500 INTERNAL SERVER ERROR
      */
+    IMAGE_CREATE_FAIL_EXCEPTION(HttpStatus.INTERNAL_SERVER_ERROR, "이미지 업로드에 실패했습니다"),
+    NO_IMAGE_FILENAME_EXCEPTION(HttpStatus.INTERNAL_SERVER_ERROR, "저장할 이미지 명이 비어있습니다"),
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "알 수 없는 서버 에러가 발생했습니다"),
     ;
 

--- a/src/main/java/indipage/org/indipage/exception/Success.java
+++ b/src/main/java/indipage/org/indipage/exception/Success.java
@@ -13,11 +13,11 @@ public enum Success {
      * 200 OK
      */
     LOGIN_SUCCESS(HttpStatus.OK, "로그인 성공"),
-
     /**
      * 201 CREATED
      */
     USER_CREATE_SUCCESS(HttpStatus.CREATED, "회원가입이 완료됐습니다."),
+    CREATE_IMAGE_SUCCESS(HttpStatus.CREATED, "이미지 업로드를 완료했습니다.")
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/indipage/org/indipage/external/client/aws/S3Service.java
+++ b/src/main/java/indipage/org/indipage/external/client/aws/S3Service.java
@@ -57,10 +57,10 @@ public class S3Service {
 
         try (InputStream inputStream = multipartFile.getInputStream()) {
             amazonS3.putObject(
-                    new PutObjectRequest(bucket + "/dev/" + folder + "/image", fileName, inputStream,
+                    new PutObjectRequest(bucket + folder + "/image", fileName, inputStream,
                             objectMetadata).withCannedAcl(
                             CannedAccessControlList.PublicRead));
-            return amazonS3.getUrl(bucket + "/dev/" + folder + "/image", fileName).toString();
+            return amazonS3.getUrl(bucket + folder + "/image", fileName).toString();
 
         } catch (IOException e) {
             throw new NotFoundException(Error.NOT_FOUND_SAVED_IMAGE_EXCEPTION,

--- a/src/main/java/indipage/org/indipage/external/client/aws/S3Service.java
+++ b/src/main/java/indipage/org/indipage/external/client/aws/S3Service.java
@@ -57,10 +57,10 @@ public class S3Service {
 
         try (InputStream inputStream = multipartFile.getInputStream()) {
             amazonS3.putObject(
-                    new PutObjectRequest(bucket + "/" + folder + "/image", fileName, inputStream,
+                    new PutObjectRequest(bucket + "/dev/" + folder + "/image", fileName, inputStream,
                             objectMetadata).withCannedAcl(
                             CannedAccessControlList.PublicRead));
-            return amazonS3.getUrl(bucket + "/" + folder + "/image", fileName).toString();
+            return amazonS3.getUrl(bucket + "/dev/" + folder + "/image", fileName).toString();
 
         } catch (IOException e) {
             throw new NotFoundException(Error.NOT_FOUND_SAVED_IMAGE_EXCEPTION,

--- a/src/main/java/indipage/org/indipage/external/client/aws/S3Service.java
+++ b/src/main/java/indipage/org/indipage/external/client/aws/S3Service.java
@@ -40,7 +40,7 @@ public class S3Service {
     private String region;
 
     private final ArrayList<String> allowedFileExtension = new ArrayList<>(
-            List.of(".jpg", "jpeg", ".png", ".JPG", ".JPEG", ".PNG"));
+            List.of(".jpg", ".jpeg", ".png", ".JPG", ".JPEG", ".PNG"));
 
     @PostConstruct
     public AmazonS3Client amazonS3Client() {

--- a/src/main/java/indipage/org/indipage/external/client/aws/S3Service.java
+++ b/src/main/java/indipage/org/indipage/external/client/aws/S3Service.java
@@ -1,5 +1,86 @@
 package indipage.org.indipage.external.client.aws;
 
-public class S3Service {
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.AmazonS3Client;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+import com.amazonaws.services.s3.model.CannedAccessControlList;
+import com.amazonaws.services.s3.model.ObjectMetadata;
+import com.amazonaws.services.s3.model.PutObjectRequest;
+import indipage.org.indipage.exception.Error;
+import indipage.org.indipage.exception.model.BadRequestException;
+import indipage.org.indipage.exception.model.NotFoundException;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+import javax.annotation.PostConstruct;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
 
+@Service
+@RequiredArgsConstructor
+public class S3Service {
+    private final AmazonS3 amazonS3;
+
+    @Value("${cloud.aws.credentials.accessKey}")
+    private String accessKey;
+
+    @Value("${cloud.aws.credentials.secretKey}")
+    private String secretKey;
+
+    @Value("${cloud.aws.s3.bucket}")
+    private String bucket;
+
+    @Value("${cloud.aws.region.static}")
+    private String region;
+
+    private final ArrayList<String> allowedFileExtension = new ArrayList<>(
+            List.of(".jpg", "jpeg", ".png", ".JPG", ".JPEG", ".PNG"));
+
+    @PostConstruct
+    public AmazonS3Client amazonS3Client() {
+        BasicAWSCredentials awsCredentials = new BasicAWSCredentials(accessKey, secretKey);
+        return (AmazonS3Client) AmazonS3ClientBuilder.standard().withRegion(region)
+                .withCredentials(new AWSStaticCredentialsProvider(awsCredentials)).build();
+    }
+
+    public String uploadIamge(MultipartFile multipartFile, String folder) {
+        String fileName = createFileName(multipartFile.getOriginalFilename());
+        ObjectMetadata objectMetadata = new ObjectMetadata();
+        objectMetadata.setContentLength(multipartFile.getSize());
+        objectMetadata.setContentType(multipartFile.getContentType());
+
+        try (InputStream inputStream = multipartFile.getInputStream()) {
+            amazonS3.putObject(
+                    new PutObjectRequest(bucket + "/" + folder + "/image", fileName, inputStream,
+                            objectMetadata).withCannedAcl(
+                            CannedAccessControlList.PublicRead));
+            return amazonS3.getUrl(bucket + "/" + folder + "/image", fileName).toString();
+
+        } catch (IOException e) {
+            throw new NotFoundException(Error.NOT_FOUND_SAVED_IMAGE_EXCEPTION,
+                    Error.NOT_FOUND_SAVED_IMAGE_EXCEPTION.getMessage());
+        }
+    }
+
+    private String createFileName(String fileName) {
+        return UUID.randomUUID().toString().concat(getFileExtension(fileName));
+    }
+
+    private String getFileExtension(String fileName) {
+        if (fileName.length() == 0) {
+            throw new NotFoundException(Error.NOT_FOUND_IMAGE_EXCEPTION, Error.NOT_FOUND_IMAGE_EXCEPTION.getMessage());
+        }
+        String idxFileName = fileName.substring(fileName.lastIndexOf("."));
+        if (!allowedFileExtension.contains(idxFileName)) {
+            throw new BadRequestException(Error.INVALID_MULTIPART_EXTENSION_EXCEPTION,
+                    Error.INVALID_MULTIPART_EXTENSION_EXCEPTION.getMessage());
+        }
+        return fileName.substring(fileName.lastIndexOf("."));
+    }
 }

--- a/src/main/java/indipage/org/indipage/external/client/aws/S3Service.java
+++ b/src/main/java/indipage/org/indipage/external/client/aws/S3Service.java
@@ -10,7 +10,7 @@ import com.amazonaws.services.s3.model.ObjectMetadata;
 import com.amazonaws.services.s3.model.PutObjectRequest;
 import indipage.org.indipage.exception.Error;
 import indipage.org.indipage.exception.model.BadRequestException;
-import indipage.org.indipage.exception.model.NotFoundException;
+import indipage.org.indipage.exception.model.CustomException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.ArrayList;
@@ -63,8 +63,8 @@ public class S3Service {
             return amazonS3.getUrl(bucket + folder + "/image", fileName).toString();
 
         } catch (IOException e) {
-            throw new NotFoundException(Error.NOT_FOUND_SAVED_IMAGE_EXCEPTION,
-                    Error.NOT_FOUND_SAVED_IMAGE_EXCEPTION.getMessage());
+            throw new CustomException(Error.IMAGE_CREATE_FAIL_EXCEPTION,
+                    Error.IMAGE_CREATE_FAIL_EXCEPTION.getMessage());
         }
     }
 
@@ -74,7 +74,8 @@ public class S3Service {
 
     private String getFileExtension(String fileName) {
         if (fileName.length() == 0) {
-            throw new NotFoundException(Error.NOT_FOUND_IMAGE_EXCEPTION, Error.NOT_FOUND_IMAGE_EXCEPTION.getMessage());
+            throw new CustomException(Error.NO_IMAGE_FILENAME_EXCEPTION,
+                    Error.NO_IMAGE_FILENAME_EXCEPTION.getMessage());
         }
         String idxFileName = fileName.substring(fileName.lastIndexOf("."));
         if (!allowedFileExtension.contains(idxFileName)) {

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -12,6 +12,10 @@ spring:
     properties:
       hibernate:
         format_sql: true
+  servlet:
+    multipart:
+      max-file-size: 3MB
+      max-request-size: 4MB
 
 server:
   port: 8080


### PR DESCRIPTION
## 📌 관련 이슈
- closed #3 

## ✨ 구현 내용
- 이미지 업로드 API 구현

##  💬 논의 사항
- 현재 requestDto의 folder 필드에 들어갈 수 있는 값을 pattern으로 설정해둠
  - 추후에 enum 등으로 변경하면 좋을 것으로 예상
- 현재 image 업로드 버킷 경로에 /dev/를 하드코딩으로 설정해둠
  - appilcation.yaml에 profile 설정을 추가하면 profile에 맞는 폴더에 저장되도록 수정해야됨
  --> 수정 완료