### PR TITLE
[FEAT] 공간 상세보기시 태그 정보 조회 추가 #13

### DIFF
--- a/src/main/java/indipage/org/indipage/api/space/controller/dto/response/SpaceDto.java
+++ b/src/main/java/indipage/org/indipage/api/space/controller/dto/response/SpaceDto.java
@@ -2,8 +2,12 @@ package indipage.org.indipage.api.space.controller.dto.response;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import indipage.org.indipage.api.tag.controller.dto.response.TagDto;
 import indipage.org.indipage.domain.Space;
 import indipage.org.indipage.domain.SpaceType;
+import indipage.org.indipage.domain.Tag;
+import java.util.List;
+import java.util.stream.Collectors;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -26,12 +30,14 @@ public class SpaceDto {
     private String peculiarityTitle;
     private String peculiarityContent;
     private String peculiarityImageUrl;
+    private List<TagDto> tagList;
 
-    public static SpaceDto of(Space space) {
+    public static SpaceDto of(Space space, List<Tag> tagList) {
 
         return new SpaceDto(space.getId(), space.getName(), space.getImageUrl(), space.getRoadAddress(),
                 space.getType(), space.getOwner(), space.getOperatingTime(), space.getClosedDays(),
                 space.getIntroduction(), space.getPeculiarityTitle(),
-                space.getPeculiarityContent(), space.getPeculiarityImageUrl());
+                space.getPeculiarityContent(), space.getPeculiarityImageUrl(),
+                tagList.stream().map(TagDto::of).collect(Collectors.toList()));
     }
 }

--- a/src/main/java/indipage/org/indipage/api/space/service/SpaceService.java
+++ b/src/main/java/indipage/org/indipage/api/space/service/SpaceService.java
@@ -1,10 +1,15 @@
 package indipage.org.indipage.api.space.service;
 
 import indipage.org.indipage.api.space.controller.dto.response.SpaceDto;
+import indipage.org.indipage.api.tag.controller.dto.response.TagDto;
+import indipage.org.indipage.domain.Relation.SpaceTagRelation;
 import indipage.org.indipage.domain.Space;
 import indipage.org.indipage.domain.SpaceRepository;
+import indipage.org.indipage.domain.Tag;
 import indipage.org.indipage.exception.Error;
 import indipage.org.indipage.exception.model.NotFoundException;
+import java.util.List;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -19,6 +24,9 @@ public class SpaceService {
                 () -> new NotFoundException(Error.NOT_FOUND_SPACE_EXCEPTION,
                         Error.NOT_FOUND_SPACE_EXCEPTION.getMessage()));
 
-        return SpaceDto.of(space);
+        List<SpaceTagRelation> spaceTagRelations = space.getSpaceTagRelations();
+        List<Tag> spaceTags = spaceTagRelations.stream().map(SpaceTagRelation::getTag).collect(Collectors.toList());
+
+        return SpaceDto.of(space, spaceTags);
     }
 }

--- a/src/main/java/indipage/org/indipage/api/tag/controller/dto/response/TagDto.java
+++ b/src/main/java/indipage/org/indipage/api/tag/controller/dto/response/TagDto.java
@@ -1,0 +1,23 @@
+package indipage.org.indipage.api.tag.controller.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import indipage.org.indipage.domain.Tag;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@JsonInclude(Include.NON_NULL)
+public class TagDto {
+    private Long id;
+    private String name;
+
+    public static TagDto of(Tag tag) {
+
+        return new TagDto(tag.getId(), tag.getName());
+    }
+}


### PR DESCRIPTION
## 📌 관련 이슈
- closed #13

## ✨ 구현 내용
- 공간 상세보기 api에 태그 정보 추가

## 💬 논의 사항
-  SpaceDto 안에 TagDto의 리스트 변수명을 tagDtoList로 하기에는 클라이언트가 데이터를 받을 때 불편한 이름일 거 같아서 tagList로 했는데 괜찮을깝쇼?
