### PR TITLE
[FEAT] 저장한 아티클 목록 조회 기능을 구현한다.

### DIFF
--- a/src/main/java/indipage/org/indipage/api/article/controller/dto/response/ArticleSummaryResponseDto.java
+++ b/src/main/java/indipage/org/indipage/api/article/controller/dto/response/ArticleSummaryResponseDto.java
@@ -17,6 +17,7 @@ public class ArticleSummaryResponseDto {
     private Long id;
     private boolean isTicketReceived;
     private LocalDateTime issueDate;
+    private String thumbnailUrl;
 
     public static ArticleSummaryResponseDto of(Space space, Article article, boolean isTicketReceived) {
         return ArticleSummaryResponseDto
@@ -27,6 +28,7 @@ public class ArticleSummaryResponseDto {
                 .id(article.getId())
                 .isTicketReceived(isTicketReceived)
                 .issueDate(article.getIssueDate())
+                .thumbnailUrl(article.getThumbnailUrl())
                 .build();
     }
 }

--- a/src/main/java/indipage/org/indipage/api/user/controller/UserController.java
+++ b/src/main/java/indipage/org/indipage/api/user/controller/UserController.java
@@ -1,22 +1,18 @@
 package indipage.org.indipage.api.user.controller;
 
+import indipage.org.indipage.api.article.controller.dto.response.ArticleSummaryResponseDto;
 import indipage.org.indipage.api.user.controller.dto.response.HasReceivedTicketResponseDto;
 import indipage.org.indipage.api.user.controller.dto.response.IsBookmarkedResponseDto;
 import indipage.org.indipage.api.user.controller.dto.response.UserDto;
 import indipage.org.indipage.api.user.service.UserService;
 import indipage.org.indipage.common.dto.ApiResponse;
 import indipage.org.indipage.exception.Success;
-import javax.validation.constraints.NotNull;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
-import org.springframework.web.bind.annotation.DeleteMapping;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.PutMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.ResponseStatus;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+
+import javax.validation.constraints.NotNull;
+import java.util.List;
 
 @RestController
 @RequestMapping("/user")
@@ -91,5 +87,11 @@ public class UserController {
     public ApiResponse deleteSpaceBookmark(@PathVariable Long spaceId) {
         userService.deleteSpaceBookmark(1L, spaceId);
         return ApiResponse.success(Success.DELETE_SPACE_BOOKMARK_SUCCESS);
+    }
+
+    @GetMapping("/bookmark/article")
+    @ResponseStatus(HttpStatus.OK)
+    public ApiResponse<List<ArticleSummaryResponseDto>> readArticleBookmarkList() {
+        return ApiResponse.success(Success.READ_ARTICLE_BOOKMARK_LIST_SUCCESS, userService.readArticleBookmarkList(1L));
     }
 }

--- a/src/main/java/indipage/org/indipage/api/user/service/UserService.java
+++ b/src/main/java/indipage/org/indipage/api/user/service/UserService.java
@@ -1,32 +1,22 @@
 package indipage.org.indipage.api.user.service;
 
+import indipage.org.indipage.api.article.controller.dto.response.ArticleSummaryResponseDto;
 import indipage.org.indipage.api.ticket.service.TicketService;
 import indipage.org.indipage.api.user.controller.dto.response.HasReceivedTicketResponseDto;
 import indipage.org.indipage.api.user.controller.dto.response.IsBookmarkedResponseDto;
 import indipage.org.indipage.api.user.controller.dto.response.UserDto;
-import indipage.org.indipage.domain.Article;
-import indipage.org.indipage.domain.ArticleBookmarkRelationRepository;
-import indipage.org.indipage.domain.ArticleRepository;
-import indipage.org.indipage.domain.InviteSpaceRelationRepository;
-import indipage.org.indipage.domain.Relation.ArticleBookmarkRelation;
-import indipage.org.indipage.domain.Relation.ArticleBookmarkRelationId;
-import indipage.org.indipage.domain.Relation.InviteSpaceRelation;
-import indipage.org.indipage.domain.Relation.InviteSpaceRelationId;
-import indipage.org.indipage.domain.Relation.SpaceBookmarkRelation;
-import indipage.org.indipage.domain.Relation.SpaceBookmarkRelationId;
-import indipage.org.indipage.domain.Space;
-import indipage.org.indipage.domain.SpaceBookmarkRelationRepository;
-import indipage.org.indipage.domain.SpaceRepository;
-import indipage.org.indipage.domain.Ticket;
-import indipage.org.indipage.domain.User;
-import indipage.org.indipage.domain.UserRepository;
+import indipage.org.indipage.domain.*;
+import indipage.org.indipage.domain.Relation.*;
 import indipage.org.indipage.exception.Error;
 import indipage.org.indipage.exception.model.ConflictException;
 import indipage.org.indipage.exception.model.NotFoundException;
-import java.util.Optional;
-import javax.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+
+import javax.transaction.Transactional;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
@@ -215,5 +205,20 @@ public class UserService {
         }
 
         return true;
+    }
+
+    public List<ArticleSummaryResponseDto> readArticleBookmarkList(final long userId) {
+        User user = findUser(userId);
+        List<ArticleSummaryResponseDto> result = new ArrayList<>();
+        List<ArticleBookmarkRelation> bookmarkRelations = articleBookmarkRelationRepository.findAllByUser(user);
+
+        for (ArticleBookmarkRelation relation : bookmarkRelations) {
+            Article article = relation.getArticle();
+            Space space = article.getSpace();
+
+            boolean isInvited = ticketService.isInvited(user, space);
+            result.add(ArticleSummaryResponseDto.of(article.getSpace(), article, isInvited));
+        }
+        return result;
     }
 }

--- a/src/main/java/indipage/org/indipage/domain/ArticleBookmarkRelationRepository.java
+++ b/src/main/java/indipage/org/indipage/domain/ArticleBookmarkRelationRepository.java
@@ -2,9 +2,10 @@ package indipage.org.indipage.domain;
 
 import indipage.org.indipage.domain.Relation.ArticleBookmarkRelation;
 import indipage.org.indipage.domain.Relation.ArticleBookmarkRelationId;
-import indipage.org.indipage.domain.Relation.FollowSpaceRelation;
-import java.util.Optional;
 import org.springframework.data.repository.Repository;
+
+import java.util.List;
+import java.util.Optional;
 
 public interface ArticleBookmarkRelationRepository extends
         Repository<ArticleBookmarkRelation, ArticleBookmarkRelationId> {
@@ -14,4 +15,6 @@ public interface ArticleBookmarkRelationRepository extends
     void save(ArticleBookmarkRelation relation);
 
     void delete(ArticleBookmarkRelation relation);
+
+    List<ArticleBookmarkRelation> findAllByUser(User user);
 }

--- a/src/main/java/indipage/org/indipage/exception/Success.java
+++ b/src/main/java/indipage/org/indipage/exception/Success.java
@@ -26,6 +26,7 @@ public enum Success {
     DELETE_ARTICLE_BOOKMARK_SUCCESS(HttpStatus.OK, "아티클 북마크 삭제 성공"),
     DELETE_SPACE_BOOKMARK_SUCCESS(HttpStatus.OK, "공간 북마크 삭제 성공"),
     READ_ARTICLE_OF_SPACE_SUCCESS(HttpStatus.OK, "공간에 대한 아티클 조회 성공"),
+    READ_ARTICLE_BOOKMARK_LIST_SUCCESS(HttpStatus.OK, "북마크한 아티클 목록 조회 성공"),
     /**
      * 201 CREATED
      */


### PR DESCRIPTION
## 📌 관련 이슈
- closed #53 

## ✨ 구현 내용
- 사용자가 저장한 아티클 목록 조회 기능을 구현한다.

## (선택) 💬 논의 사항
1. 해당 API 에서 사용되는 dto 가 아티클 목록 조회 all 탭에서 보이는 데이터와 완전히 똑같아서 해당 dto 를 그대로 썼어용. 그래서 해당 Dto 명을 바꿔야하지 싶은데 뭐가 좋을까요?
생각나는건 ArticleCardResponseDto 이정도인데,, 이건 넘 구려서,, 추천해주세욧
추천해주시면 싹 다 그걸로 리팩토링 한번 하겠슴다
2. 코드 짜다가 보니까 spaceService 에 isBookmarked 로 메서드가 두개 오버로딩 되어 있는 걸 발견했는데 추후에 서비스로 뺄 것을 고려하고 메서드명을 지은 것인지, 아니라면 메서드명을 좀 더 명확하게 가져가는 게 어떤지 물어보고 싶어용~~