### PR TITLE
 [FEAT] 저장한 아티클 목록 조회 기능을 구현한다.

### DIFF
--- a/src/main/java/indipage/org/indipage/api/article/controller/dto/response/ArticleSummaryResponseDto.java
+++ b/src/main/java/indipage/org/indipage/api/article/controller/dto/response/ArticleSummaryResponseDto.java
@@ -17,6 +17,7 @@ public class ArticleSummaryResponseDto {
     private Long id;
     private boolean isTicketReceived;
     private LocalDateTime issueDate;
+    private String thumbnailUrl;
 
     public static ArticleSummaryResponseDto of(Space space, Article article, boolean isTicketReceived) {
         return ArticleSummaryResponseDto
@@ -27,6 +28,7 @@ public class ArticleSummaryResponseDto {
                 .id(article.getId())
                 .isTicketReceived(isTicketReceived)
                 .issueDate(article.getIssueDate())
+                .thumbnailUrl(article.getThumbnailUrl())
                 .build();
     }
 }

--- a/src/main/java/indipage/org/indipage/api/article/service/ArticleService.java
+++ b/src/main/java/indipage/org/indipage/api/article/service/ArticleService.java
@@ -48,4 +48,10 @@ public class ArticleService {
 
         return result;
     }
+
+    public Article findArticleBySpace(final Space space) {
+        return articleRepository.findArticleBySpace(space).orElseThrow(
+                () -> new NotFoundException(Error.NOT_FOUND_SPACE_OF_ARTICLE_EXCEPTION,
+                        Error.NOT_FOUND_SPACE_OF_ARTICLE_EXCEPTION.getMessage()));
+    }
 }

--- a/src/main/java/indipage/org/indipage/api/space/controller/SpaceController.java
+++ b/src/main/java/indipage/org/indipage/api/space/controller/SpaceController.java
@@ -3,6 +3,7 @@ package indipage.org.indipage.api.space.controller;
 import indipage.org.indipage.api.space.controller.dto.response.BookRecommendationResponseDto;
 import indipage.org.indipage.api.space.controller.dto.response.FollowSpaceRelationResponseDto;
 import indipage.org.indipage.api.space.controller.dto.response.SpaceDto;
+import indipage.org.indipage.api.space.controller.dto.response.SpaceOfArticleResponseDto;
 import indipage.org.indipage.api.space.service.SpaceService;
 import indipage.org.indipage.common.dto.ApiResponse;
 import indipage.org.indipage.exception.Success;
@@ -45,5 +46,11 @@ public class SpaceController {
     public ApiResponse createFollowSpace(@PathVariable final Long spaceId) {
         spaceService.createFollowSpace(1L, spaceId);
         return ApiResponse.success(Success.CREATE_FOLLOW_SPACE_SUCCESS);
+    }
+
+    @GetMapping("/{spaceId}/article")
+    @ResponseStatus(HttpStatus.CREATED)
+    public ApiResponse<SpaceOfArticleResponseDto> readArticleOfSpace(@PathVariable final Long spaceId) {
+        return ApiResponse.success(Success.READ_ARTICLE_OF_SPACE_SUCCESS, spaceService.readArticleOfSpace(spaceId));
     }
 }

--- a/src/main/java/indipage/org/indipage/api/space/controller/dto/response/SpaceOfArticleResponseDto.java
+++ b/src/main/java/indipage/org/indipage/api/space/controller/dto/response/SpaceOfArticleResponseDto.java
@@ -16,7 +16,7 @@ public class SpaceOfArticleResponseDto {
     private String title;
     private String spaceType;
     private Long id;
-    private boolean isIssued;
+    private Boolean isIssued;
 
     private static boolean getIsIssued(Article article) {
         return article.getIssueDate().isBefore(LocalDateTime.now());

--- a/src/main/java/indipage/org/indipage/api/space/controller/dto/response/SpaceOfArticleResponseDto.java
+++ b/src/main/java/indipage/org/indipage/api/space/controller/dto/response/SpaceOfArticleResponseDto.java
@@ -1,0 +1,35 @@
+package indipage.org.indipage.api.space.controller.dto.response;
+
+import indipage.org.indipage.domain.Article;
+import indipage.org.indipage.domain.Space;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder
+public class SpaceOfArticleResponseDto {
+
+    private String spaceName;
+    private String title;
+    private String spaceType;
+    private Long id;
+    private boolean isIssued;
+
+    private static boolean getIsIssued(Article article) {
+        return article.getIssueDate().isBefore(LocalDateTime.now());
+    }
+
+    public static SpaceOfArticleResponseDto of(Space space, Article article) {
+        return SpaceOfArticleResponseDto
+                .builder()
+                .spaceName(space.getName())
+                .title(article.getTitle())
+                .spaceType(space.getType().getTypeName())
+                .id(article.getId())
+                .isIssued(getIsIssued(article))
+                .build();
+    }
+}

--- a/src/main/java/indipage/org/indipage/api/space/service/SpaceService.java
+++ b/src/main/java/indipage/org/indipage/api/space/service/SpaceService.java
@@ -1,8 +1,11 @@
 package indipage.org.indipage.api.space.service;
 
+import indipage.org.indipage.api.article.service.ArticleService;
 import indipage.org.indipage.api.space.controller.dto.response.BookRecommendationResponseDto;
 import indipage.org.indipage.api.space.controller.dto.response.FollowSpaceRelationResponseDto;
 import indipage.org.indipage.api.space.controller.dto.response.SpaceDto;
+import indipage.org.indipage.api.space.controller.dto.response.SpaceOfArticleResponseDto;
+import indipage.org.indipage.api.ticket.service.TicketService;
 import indipage.org.indipage.api.user.service.UserService;
 import indipage.org.indipage.domain.*;
 import indipage.org.indipage.domain.Relation.BookRecommendationRelation;
@@ -25,6 +28,8 @@ public class SpaceService {
     private final SpaceRepository spaceRepository;
     private final FollowSpaceRelationRepository followSpaceRelationRepository;
     private final UserService userService;
+    private final ArticleService articleService;
+    private final TicketService ticketService;
 
     public SpaceDto readSpace(final Long spaceId) {
         Space space = findSpace(spaceId);
@@ -59,6 +64,12 @@ public class SpaceService {
         User user = userService.findUser(userId);
         Space space = findSpace(spaceId);
         followSpaceRelationRepository.save(FollowSpaceRelation.create(user, space));
+    }
+
+    public SpaceOfArticleResponseDto readArticleOfSpace(final Long spaceId) {
+        Space space = findSpace(spaceId);
+        Article article = articleService.findArticleBySpace(space);
+        return SpaceOfArticleResponseDto.of(space, article);
     }
 
     public Space findSpace(final Long spaceId) {

--- a/src/main/java/indipage/org/indipage/api/space/service/SpaceService.java
+++ b/src/main/java/indipage/org/indipage/api/space/service/SpaceService.java
@@ -5,8 +5,8 @@ import indipage.org.indipage.api.space.controller.dto.response.BookRecommendatio
 import indipage.org.indipage.api.space.controller.dto.response.FollowSpaceRelationResponseDto;
 import indipage.org.indipage.api.space.controller.dto.response.SpaceDto;
 import indipage.org.indipage.api.space.controller.dto.response.SpaceOfArticleResponseDto;
-import indipage.org.indipage.api.ticket.service.TicketService;
 import indipage.org.indipage.api.user.service.UserService;
+import indipage.org.indipage.domain.Article;
 import indipage.org.indipage.domain.FollowSpaceRelationRepository;
 import indipage.org.indipage.domain.InviteSpaceRelationRepository;
 import indipage.org.indipage.domain.Relation.BookRecommendationRelation;
@@ -37,7 +37,6 @@ public class SpaceService {
     private final InviteSpaceRelationRepository inviteSpaceRelationRepository;
     private final UserService userService;
     private final ArticleService articleService;
-    private final TicketService ticketService;
 
     public SpaceDto readSpace(final Long spaceId) {
         Space space = findSpace(spaceId);

--- a/src/main/java/indipage/org/indipage/api/user/controller/UserController.java
+++ b/src/main/java/indipage/org/indipage/api/user/controller/UserController.java
@@ -1,22 +1,18 @@
 package indipage.org.indipage.api.user.controller;
 
+import indipage.org.indipage.api.article.controller.dto.response.ArticleSummaryResponseDto;
 import indipage.org.indipage.api.user.controller.dto.response.HasReceivedTicketResponseDto;
 import indipage.org.indipage.api.user.controller.dto.response.IsBookmarkedResponseDto;
 import indipage.org.indipage.api.user.controller.dto.response.UserDto;
 import indipage.org.indipage.api.user.service.UserService;
 import indipage.org.indipage.common.dto.ApiResponse;
 import indipage.org.indipage.exception.Success;
-import javax.validation.constraints.NotNull;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
-import org.springframework.web.bind.annotation.DeleteMapping;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.PutMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.ResponseStatus;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+
+import javax.validation.constraints.NotNull;
+import java.util.List;
 
 @RestController
 @RequestMapping("/user")
@@ -91,5 +87,11 @@ public class UserController {
     public ApiResponse deleteSpaceBookmark(@PathVariable Long spaceId) {
         userService.deleteSpaceBookmark(1L, spaceId);
         return ApiResponse.success(Success.DELETE_SPACE_BOOKMARK_SUCCESS);
+    }
+
+    @GetMapping("/bookmark/article")
+    @ResponseStatus(HttpStatus.OK)
+    public ApiResponse<List<ArticleSummaryResponseDto>> readArticleBookmarkList() {
+        return ApiResponse.success(Success.READ_ARTICLE_BOOKMARK_LIST_SUCCESS, userService.readArticleBookmarkList(1L));
     }
 }

--- a/src/main/java/indipage/org/indipage/api/user/service/UserService.java
+++ b/src/main/java/indipage/org/indipage/api/user/service/UserService.java
@@ -1,32 +1,22 @@
 package indipage.org.indipage.api.user.service;
 
+import indipage.org.indipage.api.article.controller.dto.response.ArticleSummaryResponseDto;
 import indipage.org.indipage.api.ticket.service.TicketService;
 import indipage.org.indipage.api.user.controller.dto.response.HasReceivedTicketResponseDto;
 import indipage.org.indipage.api.user.controller.dto.response.IsBookmarkedResponseDto;
 import indipage.org.indipage.api.user.controller.dto.response.UserDto;
-import indipage.org.indipage.domain.Article;
-import indipage.org.indipage.domain.ArticleBookmarkRelationRepository;
-import indipage.org.indipage.domain.ArticleRepository;
-import indipage.org.indipage.domain.InviteSpaceRelationRepository;
-import indipage.org.indipage.domain.Relation.ArticleBookmarkRelation;
-import indipage.org.indipage.domain.Relation.ArticleBookmarkRelationId;
-import indipage.org.indipage.domain.Relation.InviteSpaceRelation;
-import indipage.org.indipage.domain.Relation.InviteSpaceRelationId;
-import indipage.org.indipage.domain.Relation.SpaceBookmarkRelation;
-import indipage.org.indipage.domain.Relation.SpaceBookmarkRelationId;
-import indipage.org.indipage.domain.Space;
-import indipage.org.indipage.domain.SpaceBookmarkRelationRepository;
-import indipage.org.indipage.domain.SpaceRepository;
-import indipage.org.indipage.domain.Ticket;
-import indipage.org.indipage.domain.User;
-import indipage.org.indipage.domain.UserRepository;
+import indipage.org.indipage.domain.*;
+import indipage.org.indipage.domain.Relation.*;
 import indipage.org.indipage.exception.Error;
 import indipage.org.indipage.exception.model.ConflictException;
 import indipage.org.indipage.exception.model.NotFoundException;
-import java.util.Optional;
-import javax.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+
+import javax.transaction.Transactional;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
@@ -215,5 +205,20 @@ public class UserService {
         }
 
         return true;
+    }
+
+    public List<ArticleSummaryResponseDto> readArticleBookmarkList(final long userId) {
+        User user = findUser(userId);
+        List<ArticleSummaryResponseDto> result = new ArrayList<>();
+        List<ArticleBookmarkRelation> bookmarkRelations = articleBookmarkRelationRepository.findAllByUser(user);
+
+        for (ArticleBookmarkRelation relation : bookmarkRelations) {
+            Article article = relation.getArticle();
+            Space space = article.getSpace();
+
+            boolean isInvited = ticketService.isInvited(user, space);
+            result.add(ArticleSummaryResponseDto.of(article.getSpace(), article, isInvited));
+        }
+        return result;
     }
 }

--- a/src/main/java/indipage/org/indipage/domain/ArticleBookmarkRelationRepository.java
+++ b/src/main/java/indipage/org/indipage/domain/ArticleBookmarkRelationRepository.java
@@ -2,9 +2,10 @@ package indipage.org.indipage.domain;
 
 import indipage.org.indipage.domain.Relation.ArticleBookmarkRelation;
 import indipage.org.indipage.domain.Relation.ArticleBookmarkRelationId;
-import indipage.org.indipage.domain.Relation.FollowSpaceRelation;
-import java.util.Optional;
 import org.springframework.data.repository.Repository;
+
+import java.util.List;
+import java.util.Optional;
 
 public interface ArticleBookmarkRelationRepository extends
         Repository<ArticleBookmarkRelation, ArticleBookmarkRelationId> {
@@ -14,4 +15,6 @@ public interface ArticleBookmarkRelationRepository extends
     void save(ArticleBookmarkRelation relation);
 
     void delete(ArticleBookmarkRelation relation);
+
+    List<ArticleBookmarkRelation> findAllByUser(User user);
 }

--- a/src/main/java/indipage/org/indipage/domain/ArticleRepository.java
+++ b/src/main/java/indipage/org/indipage/domain/ArticleRepository.java
@@ -9,4 +9,6 @@ public interface ArticleRepository extends Repository<Article, Long> {
     Optional<Article> findById(Long id);
 
     List<Article> findAll();
+
+    Optional<Article> findArticleBySpace(Space space);
 }

--- a/src/main/java/indipage/org/indipage/exception/Error.java
+++ b/src/main/java/indipage/org/indipage/exception/Error.java
@@ -28,6 +28,7 @@ public enum Error {
     NOT_FOUND_TICKET_EXCEPTION(HttpStatus.NOT_FOUND, "해당 공간에 티켓이 존재하지 않습니다."),
     NOT_FOUND_ARTICLE_BOOKMARK_EXCEPTION(HttpStatus.NOT_FOUND, "해당 아티클에 대한 북마크가 존재하지 않습니다."),
     NOT_FOUND_SPACE_BOOKMARK_EXCEPTION(HttpStatus.NOT_FOUND, "해당 공간에 대한 북마크가 존재하지 않습니다."),
+    NOT_FOUND_SPACE_OF_ARTICLE_EXCEPTION(HttpStatus.NOT_FOUND, "해당 공간에 대한 아티클이 존재하지 않습니다."),
     /**
      * 409 CONFLICT
      */

--- a/src/main/java/indipage/org/indipage/exception/Success.java
+++ b/src/main/java/indipage/org/indipage/exception/Success.java
@@ -25,6 +25,7 @@ public enum Success {
     READ_IS_SPACE_BOOKMARKED_SUCCESS(HttpStatus.OK, "공간 북마크 여부 조회 성공"),
     DELETE_ARTICLE_BOOKMARK_SUCCESS(HttpStatus.OK, "아티클 북마크 삭제 성공"),
     DELETE_SPACE_BOOKMARK_SUCCESS(HttpStatus.OK, "공간 북마크 삭제 성공"),
+    READ_ARTICLE_OF_SPACE_SUCCESS(HttpStatus.OK, "공간에 대한 아티클 조회 성공"),
     /**
      * 201 CREATED
      */
@@ -35,7 +36,8 @@ public enum Success {
     CREATE_FOLLOW_SPACE_SUCCESS(HttpStatus.CREATED, "조르기 등록에 성공했습니다."),
     CREATE_RECEIVE_TICKET_SUCCESS(HttpStatus.CREATED, "티켓 수령에 성공했습니다."),
     CREATE_ARTICLE_BOOKMARK_SUCCESS(HttpStatus.CREATED, "아티클 북마크 등록에 성공했습니다."),
-    CREATE_SPACE_BOOKMARK_SUCCESS(HttpStatus.CREATED, "공간 북마크 등록에 성공했습니다.")
+    CREATE_SPACE_BOOKMARK_SUCCESS(HttpStatus.CREATED, "공간 북마크 등록에 성공했습니다."),
+
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/indipage/org/indipage/exception/Success.java
+++ b/src/main/java/indipage/org/indipage/exception/Success.java
@@ -26,6 +26,7 @@ public enum Success {
     DELETE_ARTICLE_BOOKMARK_SUCCESS(HttpStatus.OK, "아티클 북마크 삭제 성공"),
     DELETE_SPACE_BOOKMARK_SUCCESS(HttpStatus.OK, "공간 북마크 삭제 성공"),
     READ_ARTICLE_OF_SPACE_SUCCESS(HttpStatus.OK, "공간에 대한 아티클 조회 성공"),
+    READ_ARTICLE_BOOKMARK_LIST_SUCCESS(HttpStatus.OK, "북마크한 아티클 목록 조회 성공"),
     /**
      * 201 CREATED
      */


### PR DESCRIPTION
## 📌 관련 이슈
- closed #53 

## ✨ 구현 내용
- 사용자가 저장한 아티클 목록 조회 기능을 구현한다.

## (선택) 💬 논의 사항
1. 해당 API 에서 사용되는 dto 가 아티클 목록 조회 all 탭에서 보이는 데이터와 완전히 똑같아서 해당 dto 를 그대로 썼어용. 그래서 해당 Dto 명을 바꿔야하지 싶은데 뭐가 좋을까요?
생각나는건 ArticleCardResponseDto 이정도인데,, 이건 넘 구려서,, 추천해주세욧
추천해주시면 싹 다 그걸로 리팩토링 한번 하겠슴다
2. 코드 짜다가 보니까 spaceService 에 isBookmarked 로 메서드가 두개 오버로딩 되어 있는 걸 발견했는데 추후에 서비스로 뺄 것을 고려하고 메서드명을 지은 것인지, 아니라면 메서드명을 좀 더 명확하게 가져가는 게 어떤지 물어보고 싶어용~~
