### PR TITLE
[FEAT] 유저가 수령한 티켓 리스트 조회 api를 구현한다.

### DIFF
--- a/src/main/java/indipage/org/indipage/api/space/controller/SpaceController.java
+++ b/src/main/java/indipage/org/indipage/api/space/controller/SpaceController.java
@@ -3,7 +3,7 @@ package indipage.org.indipage.api.space.controller;
 import indipage.org.indipage.api.space.controller.dto.response.BookRecommendationResponseDto;
 import indipage.org.indipage.api.space.controller.dto.response.FollowSpaceRelationResponseDto;
 import indipage.org.indipage.api.space.controller.dto.response.SpaceDto;
-import indipage.org.indipage.api.space.controller.dto.response.SpaceOfArticleResponseDto;
+import indipage.org.indipage.api.space.controller.dto.response.ArticleOfSpaceResponseDto;
 import indipage.org.indipage.api.space.service.SpaceService;
 import indipage.org.indipage.common.dto.ApiResponse;
 import indipage.org.indipage.exception.Success;
@@ -50,7 +50,7 @@ public class SpaceController {
 
     @GetMapping("/{spaceId}/article")
     @ResponseStatus(HttpStatus.CREATED)
-    public ApiResponse<SpaceOfArticleResponseDto> readArticleOfSpace(@PathVariable final Long spaceId) {
+    public ApiResponse<ArticleOfSpaceResponseDto> readArticleOfSpace(@PathVariable final Long spaceId) {
         return ApiResponse.success(Success.READ_ARTICLE_OF_SPACE_SUCCESS, spaceService.readArticleOfSpace(spaceId));
     }
   

--- a/src/main/java/indipage/org/indipage/api/space/controller/dto/response/ArticleOfSpaceResponseDto.java
+++ b/src/main/java/indipage/org/indipage/api/space/controller/dto/response/ArticleOfSpaceResponseDto.java
@@ -10,26 +10,28 @@ import java.time.LocalDateTime;
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @Builder
-public class SpaceOfArticleResponseDto {
+public class ArticleOfSpaceResponseDto {
 
     private String spaceName;
     private String title;
     private String spaceType;
     private Long id;
     private Boolean isIssued;
+    private String imageUrl;
 
     private static boolean getIsIssued(Article article) {
         return article.getIssueDate().isBefore(LocalDateTime.now());
     }
 
-    public static SpaceOfArticleResponseDto of(Space space, Article article) {
-        return SpaceOfArticleResponseDto
+    public static ArticleOfSpaceResponseDto of(Space space, Article article) {
+        return ArticleOfSpaceResponseDto
                 .builder()
                 .spaceName(space.getName())
                 .title(article.getTitle())
                 .spaceType(space.getType().getTypeName())
                 .id(article.getId())
                 .isIssued(getIsIssued(article))
+                .imageUrl(article.getThumbnailUrl())
                 .build();
     }
 }

--- a/src/main/java/indipage/org/indipage/api/space/service/SpaceService.java
+++ b/src/main/java/indipage/org/indipage/api/space/service/SpaceService.java
@@ -4,7 +4,7 @@ import indipage.org.indipage.api.article.service.ArticleService;
 import indipage.org.indipage.api.space.controller.dto.response.BookRecommendationResponseDto;
 import indipage.org.indipage.api.space.controller.dto.response.FollowSpaceRelationResponseDto;
 import indipage.org.indipage.api.space.controller.dto.response.SpaceDto;
-import indipage.org.indipage.api.space.controller.dto.response.SpaceOfArticleResponseDto;
+import indipage.org.indipage.api.space.controller.dto.response.ArticleOfSpaceResponseDto;
 import indipage.org.indipage.api.user.service.UserService;
 import indipage.org.indipage.domain.Article;
 import indipage.org.indipage.domain.FollowSpaceRelationRepository;
@@ -89,10 +89,10 @@ public class SpaceService {
         followSpaceRelationRepository.save(FollowSpaceRelation.create(user, space));
     }
 
-    public SpaceOfArticleResponseDto readArticleOfSpace(final Long spaceId) {
+    public ArticleOfSpaceResponseDto readArticleOfSpace(final Long spaceId) {
         Space space = findSpace(spaceId);
         Article article = articleService.findArticleBySpace(space);
-        return SpaceOfArticleResponseDto.of(space, article);
+        return ArticleOfSpaceResponseDto.of(space, article);
     }
 
     public Space findSpace(final Long spaceId) {

--- a/src/main/java/indipage/org/indipage/api/ticket/controller/dto/response/ReceivedTicketResponseDto.java
+++ b/src/main/java/indipage/org/indipage/api/ticket/controller/dto/response/ReceivedTicketResponseDto.java
@@ -1,0 +1,26 @@
+package indipage.org.indipage.api.ticket.controller.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import indipage.org.indipage.domain.Space;
+import indipage.org.indipage.domain.Ticket;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@JsonInclude(Include.NON_NULL)
+public class ReceivedTicketResponseDto {
+    private Long ticketId;
+
+    private String imageUrl;
+
+    private Long spaceId;
+
+    public static ReceivedTicketResponseDto of(Ticket ticket, Space space) {
+        return new ReceivedTicketResponseDto(ticket.getId(), ticket.getTicketImageUrl(), space.getId());
+    }
+}

--- a/src/main/java/indipage/org/indipage/api/user/controller/UserController.java
+++ b/src/main/java/indipage/org/indipage/api/user/controller/UserController.java
@@ -1,6 +1,7 @@
 package indipage.org.indipage.api.user.controller;
 
 import indipage.org.indipage.api.article.controller.dto.response.ArticleSummaryResponseDto;
+import indipage.org.indipage.api.ticket.controller.dto.response.ReceivedTicketResponseDto;
 import indipage.org.indipage.api.user.controller.dto.response.HasReceivedTicketResponseDto;
 import indipage.org.indipage.api.user.controller.dto.response.IsBookmarkedResponseDto;
 import indipage.org.indipage.api.user.controller.dto.response.UserDto;
@@ -93,5 +94,11 @@ public class UserController {
     @ResponseStatus(HttpStatus.OK)
     public ApiResponse<List<ArticleSummaryResponseDto>> readArticleBookmarkList() {
         return ApiResponse.success(Success.READ_ARTICLE_BOOKMARK_LIST_SUCCESS, userService.readArticleBookmarkList(1L));
+    }
+
+    @GetMapping("/ticket")
+    @ResponseStatus(HttpStatus.OK)
+    public ApiResponse<List<ReceivedTicketResponseDto>> readReceivedTicket() {
+        return ApiResponse.success(Success.READ_RECEIVED_TICKET_SUCCESS, userService.readReceivedTicket(1L));
     }
 }

--- a/src/main/java/indipage/org/indipage/api/user/service/UserService.java
+++ b/src/main/java/indipage/org/indipage/api/user/service/UserService.java
@@ -1,6 +1,7 @@
 package indipage.org.indipage.api.user.service;
 
 import indipage.org.indipage.api.article.controller.dto.response.ArticleSummaryResponseDto;
+import indipage.org.indipage.api.ticket.controller.dto.response.ReceivedTicketResponseDto;
 import indipage.org.indipage.api.ticket.service.TicketService;
 import indipage.org.indipage.api.user.controller.dto.response.HasReceivedTicketResponseDto;
 import indipage.org.indipage.api.user.controller.dto.response.IsBookmarkedResponseDto;
@@ -214,6 +215,20 @@ public class UserService {
 
             boolean isInvited = ticketService.isInvited(user, space);
             result.add(ArticleSummaryResponseDto.of(article.getSpace(), article, isInvited));
+        }
+        return result;
+    }
+
+    public List<ReceivedTicketResponseDto> readReceivedTicket(final Long userId) {
+        User user = findUser(userId);
+        List<ReceivedTicketResponseDto> result = new ArrayList<>();
+        List<InviteSpaceRelation> inviteRelations = inviteSpaceRelationRepository.findAllByUserAndHasVisitedIsFalse(user);
+
+        for (InviteSpaceRelation relation : inviteRelations) {
+            Space spaceOfTicket = relation.getSpace();
+            Ticket ticket = ticketService.findTicketWithSpace(spaceOfTicket);
+
+            result.add(ReceivedTicketResponseDto.of(ticket, spaceOfTicket));
         }
         return result;
     }

--- a/src/main/java/indipage/org/indipage/domain/InviteSpaceRelationRepository.java
+++ b/src/main/java/indipage/org/indipage/domain/InviteSpaceRelationRepository.java
@@ -2,6 +2,7 @@ package indipage.org.indipage.domain;
 
 import indipage.org.indipage.domain.Relation.InviteSpaceRelation;
 import indipage.org.indipage.domain.Relation.InviteSpaceRelationId;
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.repository.Repository;
 
@@ -9,4 +10,6 @@ public interface InviteSpaceRelationRepository extends Repository<InviteSpaceRel
     Optional<InviteSpaceRelation> findByInviteSpaceRelationId(InviteSpaceRelationId id);
 
     void save(InviteSpaceRelation relation);
+
+    List<InviteSpaceRelation> findAllByUserAndHasVisitedIsFalse(User user);
 }

--- a/src/main/java/indipage/org/indipage/exception/Success.java
+++ b/src/main/java/indipage/org/indipage/exception/Success.java
@@ -27,6 +27,7 @@ public enum Success {
     DELETE_SPACE_BOOKMARK_SUCCESS(HttpStatus.OK, "공간 북마크 삭제 성공"),
     READ_ARTICLE_OF_SPACE_SUCCESS(HttpStatus.OK, "공간에 대한 아티클 조회 성공"),
     READ_ARTICLE_BOOKMARK_LIST_SUCCESS(HttpStatus.OK, "북마크한 아티클 목록 조회 성공"),
+    READ_RECEIVED_TICKET_SUCCESS(HttpStatus.OK, "수령한 티켓 목록 조회에 성공했습니다."),
     /**
      * 201 CREATED
      */


### PR DESCRIPTION
## 📌 관련 이슈
- closed #61 

## ✨ 구현 내용
- 수령한 티켓 리스트 조회 구현
- 공간에 대한 아티클 조회에 아티클 썸네일 url 추가

