### PR TITLE
[ADD] 뷰 수정에 따라 주소의 카테고리명을 사용하지 않는 검색 응답형태 추가 #83

### DIFF
--- a/src/main/java/indipage/org/indipage/api/space/controller/SpaceController.java
+++ b/src/main/java/indipage/org/indipage/api/space/controller/SpaceController.java
@@ -61,7 +61,7 @@ public class SpaceController {
 
     @GetMapping("/list")
     @ResponseStatus(HttpStatus.OK)
-    public ApiResponse<List<SpaceSearchWithCategoryResponseDto>> searchWithAddress(@RequestParam(value = "keyword") Optional<String> searchWord) {
+    public ApiResponse<List<SpaceSearchResponseDto>> searchWithAddress(@RequestParam(value = "keyword") Optional<String> searchWord) {
         return ApiResponse.success(Success.SEARCH_SPACE_SUCCESS, spaceService.searchSpace(searchWord));
     }
 }

--- a/src/main/java/indipage/org/indipage/api/space/service/SpaceService.java
+++ b/src/main/java/indipage/org/indipage/api/space/service/SpaceService.java
@@ -111,7 +111,25 @@ public class SpaceService {
         return resultMap;
     }
 
-    public List<SpaceSearchWithCategoryResponseDto> searchSpace(Optional<String> searchWord) {
+    private List<Space> getResultOfSearch(Optional<String> searchWord) {
+        if (searchWord.isEmpty()) {
+            return spaceRepository.findAll();
+        }
+        return spaceRepository.searchByAddress(searchWord.get());
+    }
+
+    public List<SpaceSearchResponseDto> searchSpace(Optional<String> searchWord) {
+        List<Space> spaces = getResultOfSearch(searchWord);
+
+        List<SpaceSearchResponseDto> result = new ArrayList<>();
+
+        for (Space space : spaces) {
+            result.add(SpaceSearchResponseDto.of(space));
+        }
+        return result;
+    }
+
+    public List<SpaceSearchWithCategoryResponseDto> searchSpaceWithCategoryName(Optional<String> searchWord) {
 
         if (searchWord.isEmpty()) {
             return getResultWithoutSearchWord();
@@ -126,6 +144,7 @@ public class SpaceService {
 
         return result;
     }
+
 
     private String getCategoryNameOfAddress(Space space) {
         String metroGovernment = space.getAddress().getMetroGovernment();


### PR DESCRIPTION
## 📌 관련 이슈
- closed #83 

## ✨ 구현 내용
- 뷰 수정에 따라 주소의 카테고리명을 사용하지 않는 검색 응답형태 추가

