### PR TITLE
[FEAT] 아티클에서 보이는 티켓 정보를 추가한다.

### DIFF
--- a/src/main/java/indipage/org/indipage/api/ticket/controller/dto/response/TicketDto.java
+++ b/src/main/java/indipage/org/indipage/api/ticket/controller/dto/response/TicketDto.java
@@ -18,12 +18,14 @@ public class TicketDto {
     private Long id;
     private String ticketImageUrl;
     private String cardImageUrl;
+    private String ticketForArticleImageUrl;
 
     public static TicketDto of(Ticket ticket) {
         return TicketDto.builder()
                 .id(ticket.getId())
                 .ticketImageUrl(ticket.getTicketImageUrl())
                 .cardImageUrl(ticket.getCardImageUrl())
+                .ticketForArticleImageUrl(ticket.getTicketForArticleImageUrl())
                 .build();
     }
 

--- a/src/main/java/indipage/org/indipage/domain/Ticket.java
+++ b/src/main/java/indipage/org/indipage/domain/Ticket.java
@@ -20,6 +20,9 @@ public class Ticket {
     @Column(nullable = false)
     private String cardImageUrl;
 
+    @Column(nullable = false)
+    private String ticketForArticleImageUrl;
+
     @OneToOne
     @JoinColumn(name = "space_id")
     private Space space;


### PR DESCRIPTION
## 📌 관련 이슈
- closed #102

## ✨ 구현 내용
- 아티클에서 티켓 수령 여부 조회 API 결과에 해당 정보 추가 (ticketForArticleImageUrl)