### PR TITLE
[ADD] 소셜 로그인 구현 시 공통으로 사용되는 클래스들을 추가한다.

### DIFF
--- a/src/main/java/indipage/org/indipage/auth/Platform.java
+++ b/src/main/java/indipage/org/indipage/auth/Platform.java
@@ -1,0 +1,6 @@
+package indipage.org.indipage.auth;
+
+public enum Platform {
+    GOOGLE(),
+    APPLE();
+}

--- a/src/main/java/indipage/org/indipage/auth/dto/OAuthUserResponseDto.java
+++ b/src/main/java/indipage/org/indipage/auth/dto/OAuthUserResponseDto.java
@@ -1,0 +1,17 @@
+package indipage.org.indipage.auth.dto;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.NoArgsConstructor;
+
+@Builder
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class OAuthUserResponseDto {
+
+    private String email;
+
+    private String name;
+
+}

--- a/src/main/java/indipage/org/indipage/auth/service/AppleOauthClient.java
+++ b/src/main/java/indipage/org/indipage/auth/service/AppleOauthClient.java
@@ -1,7 +1,12 @@
 package indipage.org.indipage.auth.service;
 
+import indipage.org.indipage.auth.dto.OAuthUserResponseDto;
 import org.springframework.stereotype.Component;
 
 @Component
-public interface AppleOauthClient extends OAuthClient {
+public class AppleOauthClient implements OAuthClient {
+    @Override
+    public OAuthUserResponseDto getMember(String accessToken) {
+        return null;
+    }
 }

--- a/src/main/java/indipage/org/indipage/auth/service/AppleOauthClient.java
+++ b/src/main/java/indipage/org/indipage/auth/service/AppleOauthClient.java
@@ -1,0 +1,7 @@
+package indipage.org.indipage.auth.service;
+
+import org.springframework.stereotype.Component;
+
+@Component
+public interface AppleOauthClient extends OAuthClient {
+}

--- a/src/main/java/indipage/org/indipage/auth/service/OAuthClient.java
+++ b/src/main/java/indipage/org/indipage/auth/service/OAuthClient.java
@@ -1,0 +1,7 @@
+package indipage.org.indipage.auth.service;
+
+import indipage.org.indipage.auth.dto.OAuthUserResponseDto;
+
+public interface OAuthClient {
+    OAuthUserResponseDto getMember(String accessToken);
+}

--- a/src/main/java/indipage/org/indipage/auth/service/OAuthClientProvider.java
+++ b/src/main/java/indipage/org/indipage/auth/service/OAuthClientProvider.java
@@ -1,0 +1,27 @@
+package indipage.org.indipage.auth.service;
+
+import indipage.org.indipage.auth.Platform;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import javax.annotation.PostConstruct;
+import java.util.HashMap;
+import java.util.Map;
+
+@Component
+@RequiredArgsConstructor
+public class OAuthClientProvider {
+
+    private static final Map<Platform, OAuthClient> oAuthClientMap = new HashMap<>();
+
+    private final AppleOauthClient appleOauthClient;
+
+    @PostConstruct
+    void initializeOAuthClientMap() {
+        oAuthClientMap.put(Platform.APPLE, appleOauthClient);
+    }
+
+    public OAuthClient getClient(Platform oAuthProvider) {
+        return oAuthClientMap.get(oAuthProvider);
+    }
+}

--- a/src/main/java/indipage/org/indipage/domain/User.java
+++ b/src/main/java/indipage/org/indipage/domain/User.java
@@ -26,6 +26,10 @@ public class User extends CreatedTimeBaseEntity {
     private String email;
 
     @Column
+    @Enumerated(value = EnumType.STRING)
+    private String platform;
+
+    @Column
     private LocalDateTime slideAt;
 
     @OneToMany(fetch = FetchType.LAZY, mappedBy = "user")


### PR DESCRIPTION
## 📌 관련 이슈
- closed #104 

## ✨ 구현 내용
- platform enum 클래스 추가
- platform 컬럼 user 엔티티에 추가
- 플랫폼에 알맞는 client 를 반환하는 provider 기능 구현

## 💬 논의 사항
- OAuthClient 의 역할은 특정한 메서드들을 구현하도록 강제하고 client 들을 하나로 묶을 수 있다는 점인데, 우리가 FeignClient 를 쓰기로 해서 OAuthClient 를 구현하는 구현체도 결국에는 Interface 가 되어야 합니당. 구현이 아니니 구현체라고 하기도 애매하네요 . . 우선은 provider 의 구현을 위해서 extends 로 처리해놓기는 했는데, 이가 어떤 의미가 있을지 사실 잘 모르겠어요.. client 들을 하나로 묶을 수는 있지만 메서드들의 구현은 강제하지 못할 것 같아 해당 구조가 맞을지 많이 혼란스럽습니당..
