### PR TITLE
[FEAT] 유저 인증 과정에서 사용할 JWT 로직을 구현한다. #106

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -45,6 +45,11 @@ dependencies {
 
     // swagger
     implementation 'org.springdoc:springdoc-openapi-ui:1.7.0'
+
+    // JWT
+    implementation group: 'io.jsonwebtoken', name: 'jjwt-api', version: '0.11.2'
+    implementation group: 'io.jsonwebtoken', name: 'jjwt-impl', version: '0.11.2'
+    implementation group: 'io.jsonwebtoken', name: 'jjwt-jackson', version: '0.11.2'
 }
 
 tasks.named('test') {

--- a/src/main/java/indipage/org/indipage/auth/JwtProvider.java
+++ b/src/main/java/indipage/org/indipage/auth/JwtProvider.java
@@ -14,7 +14,7 @@ import java.util.Date;
 import javax.annotation.PostConstruct;
 import org.springframework.beans.factory.annotation.Value;
 
-public class JwtService {
+public class JwtProvider {
 
     @Value("${jwt.secret}")
     private String jwtSecret;

--- a/src/main/java/indipage/org/indipage/auth/JwtService.java
+++ b/src/main/java/indipage/org/indipage/auth/JwtService.java
@@ -1,0 +1,73 @@
+package indipage.org.indipage.auth;
+
+import indipage.org.indipage.exception.Error;
+import indipage.org.indipage.exception.model.UnauthorizedException;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.Header;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.security.Keys;
+import java.nio.charset.StandardCharsets;
+import java.security.Key;
+import java.util.Base64;
+import java.util.Date;
+import javax.annotation.PostConstruct;
+import org.springframework.beans.factory.annotation.Value;
+
+public class JwtService {
+
+    @Value("${jwt.secret}")
+    private String jwtSecret;
+
+    @PostConstruct
+    protected void init() {
+        jwtSecret = Base64.getEncoder().encodeToString(jwtSecret.getBytes(StandardCharsets.UTF_8));
+    }
+
+    public String issuedToken(String userId) {
+        final Date now = new Date();
+
+        final Claims claims = Jwts.claims().setSubject("access_token").setIssuedAt(now)
+                .setExpiration(new Date(now.getTime() + 120 * 60 * 1000L));
+
+        claims.put("userId", userId);
+
+        return Jwts.builder()
+                .setHeaderParam(Header.TYPE, Header.JWT_TYPE)
+                .setClaims(claims)
+                .signWith(getSigningKey())
+                .compact();
+    }
+
+    private Key getSigningKey() {
+        final byte[] keyBytes = jwtSecret.getBytes(StandardCharsets.UTF_8);
+        return Keys.hmacShaKeyFor(keyBytes);
+    }
+
+    public boolean verifyToken(String token) {
+        try {
+            final Claims claims = getBody(token);
+            return true;
+        } catch (RuntimeException e) {
+            if (e instanceof ExpiredJwtException) {
+                throw new UnauthorizedException(Error.TOKEN_TIME_EXPIRED_EXCEPTION,
+                        Error.TOKEN_TIME_EXPIRED_EXCEPTION.getMessage());
+
+            }
+            return false;
+        }
+    }
+
+    private Claims getBody(final String token) {
+        return Jwts.parserBuilder()
+                .setSigningKey(getSigningKey())
+                .build()
+                .parseClaimsJws(token)
+                .getBody();
+    }
+
+    public String getJwtContents(String token) {
+        final Claims claims = getBody(token);
+        return (String) claims.get("userId");
+    }
+}

--- a/src/main/java/indipage/org/indipage/config/resolver/UserId.java
+++ b/src/main/java/indipage/org/indipage/config/resolver/UserId.java
@@ -1,0 +1,11 @@
+package indipage.org.indipage.config.resolver;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface UserId {
+}

--- a/src/main/java/indipage/org/indipage/config/resolver/UserIdResolver.java
+++ b/src/main/java/indipage/org/indipage/config/resolver/UserIdResolver.java
@@ -1,0 +1,44 @@
+package indipage.org.indipage.config.resolver;
+
+import indipage.org.indipage.auth.JwtService;
+import javax.servlet.http.HttpServletRequest;
+import javax.validation.constraints.NotNull;
+import lombok.RequiredArgsConstructor;
+import org.springframework.core.MethodParameter;
+import org.springframework.stereotype.Component;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+@RequiredArgsConstructor
+@Component
+public class UserIdResolver implements HandlerMethodArgumentResolver {
+    private final JwtService jwtService;
+
+    @Override
+    public boolean supportsParameter(MethodParameter parameter) {
+        return parameter.hasParameterAnnotation(UserId.class) && Long.class.equals(parameter.getParameterType());
+    }
+
+    @Override
+    public Object resolveArgument(@NotNull MethodParameter parameter, ModelAndViewContainer modelAndViewContainer,
+                                  @NotNull NativeWebRequest webRequest, WebDataBinderFactory binderFactory) {
+        final HttpServletRequest request = (HttpServletRequest) webRequest.getNativeRequest();
+        final String token = request.getHeader("Authorization");
+
+        if (!jwtService.verifyToken(token)) {
+            throw new RuntimeException(
+                    String.format("USER_ID를 가져오지 못했습니다. (%s - %s)", parameter.getClass(), parameter.getMethod()));
+        }
+
+        // 유저 아이디 반환
+        final String tokenContents = jwtService.getJwtContents(token);
+        try {
+            return Long.parseLong(tokenContents);
+        } catch (NumberFormatException e) {
+            throw new RuntimeException(
+                    String.format("USER_ID를 가져오지 못했습니다. (%s - %s)", parameter.getClass(), parameter.getMethod()));
+        }
+    }
+}

--- a/src/main/java/indipage/org/indipage/config/resolver/UserIdResolver.java
+++ b/src/main/java/indipage/org/indipage/config/resolver/UserIdResolver.java
@@ -1,6 +1,6 @@
 package indipage.org.indipage.config.resolver;
 
-import indipage.org.indipage.auth.JwtService;
+import indipage.org.indipage.auth.JwtProvider;
 import javax.servlet.http.HttpServletRequest;
 import javax.validation.constraints.NotNull;
 import lombok.RequiredArgsConstructor;
@@ -14,7 +14,7 @@ import org.springframework.web.method.support.ModelAndViewContainer;
 @RequiredArgsConstructor
 @Component
 public class UserIdResolver implements HandlerMethodArgumentResolver {
-    private final JwtService jwtService;
+    private final JwtProvider jwtProvider;
 
     @Override
     public boolean supportsParameter(MethodParameter parameter) {
@@ -27,13 +27,13 @@ public class UserIdResolver implements HandlerMethodArgumentResolver {
         final HttpServletRequest request = (HttpServletRequest) webRequest.getNativeRequest();
         final String token = request.getHeader("Authorization");
 
-        if (!jwtService.verifyToken(token)) {
+        if (!jwtProvider.verifyToken(token)) {
             throw new RuntimeException(
                     String.format("USER_ID를 가져오지 못했습니다. (%s - %s)", parameter.getClass(), parameter.getMethod()));
         }
 
         // 유저 아이디 반환
-        final String tokenContents = jwtService.getJwtContents(token);
+        final String tokenContents = jwtProvider.getJwtContents(token);
         try {
             return Long.parseLong(tokenContents);
         } catch (NumberFormatException e) {

--- a/src/main/java/indipage/org/indipage/exception/Error.java
+++ b/src/main/java/indipage/org/indipage/exception/Error.java
@@ -17,7 +17,7 @@ public enum Error {
     /**
      * 401 UNAUTHORIZED
      */
-
+    TOKEN_TIME_EXPIRED_EXCEPTION(HttpStatus.UNAUTHORIZED, "만료된 토큰입니다."),
     /**
      * 404 NOT FOUND
      */

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -56,6 +56,9 @@ springdoc:
     cache:
       disabled: true
 
+jwt:
+  secret: ${jwt-secret}
+
 # set1
 ---
 


### PR DESCRIPTION
## 📌 관련 이슈
- closed #106 

## ✨ 구현 내용
- JWT 토큰을 발급하고 검사하고 데이터를 반환하는 JwtProvider 클래스 구현
- Controller에서 사용할 어노테이션을 구현
- 어노테이션의 동작을 지정하는 resolver 구현

## (선택) 💬 논의 사항
- JwtProvider는 유저 인증 과정에서 사용하기 때문에 auth 패키지 밑에 생성했고, 이외 어노테이션과 resolver는 애플리케이션 전역적으로 활용되므로 config 아래 생성했는데 어떻게 생각하시나욤
