### PR TITLE
[FEAT] 구글 소셜 로그인을 구현한다.

### DIFF
--- a/src/main/java/indipage/org/indipage/auth/service/JWKs.java
+++ b/src/main/java/indipage/org/indipage/auth/service/JWKs.java
@@ -1,4 +1,4 @@
-package indipage.org.indipage.auth.service.apple;
+package indipage.org.indipage.auth.service;
 
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -12,14 +12,14 @@ import java.util.Optional;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
-public class ApplePublicKeys {
+public class JWKs {
 
-    private List<ApplePublicKey> keys;
+    private List<JWKey> keys;
 
     @Getter
     @NoArgsConstructor(access = AccessLevel.PRIVATE)
     @AllArgsConstructor(access = AccessLevel.PRIVATE)
-    public class ApplePublicKey {
+    static public class JWKey {
         private String kty;
         private String kid;
         private String use;
@@ -28,8 +28,8 @@ public class ApplePublicKeys {
         private String e;
     }
 
-    public ApplePublicKey getPublicKey(String alg, String kid) {
-        Optional<ApplePublicKey> matchingKey = this.keys
+    public JWKey getRightJWK(String alg, String kid) {
+        Optional<JWKey> matchingKey = this.keys
                 .stream()
                 .filter(k -> k.getAlg().equals(alg) && k.getKid().equals(kid))
                 .findFirst();

--- a/src/main/java/indipage/org/indipage/auth/service/PublicKeyGenerator.java
+++ b/src/main/java/indipage/org/indipage/auth/service/PublicKeyGenerator.java
@@ -1,9 +1,7 @@
-package indipage.org.indipage.auth.service.apple;
+package indipage.org.indipage.auth.service;
 
-import lombok.RequiredArgsConstructor;
-import org.springframework.stereotype.Component;
-import org.springframework.util.Base64Utils;
-
+import indipage.org.indipage.auth.service.JWKs;
+import indipage.org.indipage.auth.service.JWKs.JWKey;
 import java.math.BigInteger;
 import java.security.KeyFactory;
 import java.security.NoSuchAlgorithmException;
@@ -11,29 +9,32 @@ import java.security.PublicKey;
 import java.security.spec.InvalidKeySpecException;
 import java.security.spec.RSAPublicKeySpec;
 import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.util.Base64Utils;
 
 @Component
 @RequiredArgsConstructor
-public class ApplePublicKeyGenerator {
+public class PublicKeyGenerator {
 
     private static final String KEY_OF_HEADER_ALGORITHM = "alg";
     private static final String KEY_OF_HEADER_KEY_ID = "kid";
     private static final int POSITIVE_SIGN = 1;
 
-    public PublicKey generatePublicKey(final Map<String, String> headers, final ApplePublicKeys publicKeys) {
-        ApplePublicKeys.ApplePublicKey publicKey = getApplePublicKeyWithDecodedHeader(headers, publicKeys);
-        RSAPublicKeySpec publicKeySpec = generateRSAPublicKeySpecFromApplePublicKey(publicKey);
+    public PublicKey generatePublicKey(final Map<String, String> headers, final JWKs publicKeys) {
+        JWKey publicKey = getRightJWKWithDecodedHeader(headers, publicKeys);
+        RSAPublicKeySpec publicKeySpec = generateRSAPublicKeySpecFromJWK(publicKey);
         return generatePublicKeyFromKeySpecAndKeyType(publicKey.getKty(), publicKeySpec);
     }
 
-    private ApplePublicKeys.ApplePublicKey getApplePublicKeyWithDecodedHeader(final Map<String, String> headers, final ApplePublicKeys publicKeys) {
+    private JWKey getRightJWKWithDecodedHeader(final Map<String, String> headers, final JWKs publicKeys) {
         String alg = headers.get(KEY_OF_HEADER_ALGORITHM);
         String kid = headers.get(KEY_OF_HEADER_KEY_ID);
 
-        return publicKeys.getPublicKey(alg, kid);
+        return publicKeys.getRightJWK(alg, kid);
     }
 
-    private RSAPublicKeySpec generateRSAPublicKeySpecFromApplePublicKey(final ApplePublicKeys.ApplePublicKey publicKey) {
+    private RSAPublicKeySpec generateRSAPublicKeySpecFromJWK(final JWKey publicKey) {
         byte[] nBytes = Base64Utils.decodeFromUrlSafeString(publicKey.getN());
         byte[] eBytes = Base64Utils.decodeFromUrlSafeString(publicKey.getE());
 

--- a/src/main/java/indipage/org/indipage/auth/service/apple/AppleOAuthClient.java
+++ b/src/main/java/indipage/org/indipage/auth/service/apple/AppleOAuthClient.java
@@ -1,7 +1,9 @@
 package indipage.org.indipage.auth.service.apple;
 
 import indipage.org.indipage.auth.dto.OAuthUserResponseDto;
+import indipage.org.indipage.auth.service.JWKs;
 import indipage.org.indipage.auth.service.OAuthClient;
+import indipage.org.indipage.auth.service.PublicKeyGenerator;
 import io.jsonwebtoken.Claims;
 import lombok.RequiredArgsConstructor;
 import org.springframework.cloud.openfeign.FeignClient;
@@ -17,14 +19,14 @@ public class AppleOAuthClient implements OAuthClient {
 
     private final ApplePublicKeyClient publicKeyClient;
     private final AppleIdentityTokenProcessor identityTokenProcessor;
-    private final ApplePublicKeyGenerator applePublicKeyGenerator;
+    private final PublicKeyGenerator publicKeyGenerator;
 
     @Override
     public OAuthUserResponseDto getUser(String accessToken) {
         Map<String, String> header = identityTokenProcessor.getParsedHeader(accessToken);
-        ApplePublicKeys applePublicKeys = publicKeyClient.getApplePublicKeys();
+        JWKs JWKs = publicKeyClient.getJWKs();
 
-        PublicKey publicKey = applePublicKeyGenerator.generatePublicKey(header, applePublicKeys);
+        PublicKey publicKey = publicKeyGenerator.generatePublicKey(header, JWKs);
 
         Claims claims = identityTokenProcessor.extractClaimsFromIdentityToken(accessToken, publicKey);
 
@@ -36,6 +38,6 @@ public class AppleOAuthClient implements OAuthClient {
     @FeignClient(name = "apple-public-key-client", url = "https://appleid.apple.com/auth")
     public interface ApplePublicKeyClient {
         @GetMapping("/keys")
-        ApplePublicKeys getApplePublicKeys();
+        JWKs getJWKs();
     }
 }

--- a/src/main/java/indipage/org/indipage/auth/service/google/GoogleIdTokenProcessor.java
+++ b/src/main/java/indipage/org/indipage/auth/service/google/GoogleIdTokenProcessor.java
@@ -1,2 +1,56 @@
-package indipage.org.indipage.auth.service.google;public class GoogleIdTokenProcessor {
+package indipage.org.indipage.auth.service.google;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import indipage.org.indipage.exception.Error;
+import indipage.org.indipage.exception.model.UnauthorizedException;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.Jwts;
+import java.security.PublicKey;
+import java.util.Map;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.util.Base64Utils;
+
+@Component
+public class GoogleIdTokenProcessor {
+
+    @Value("${oauth.google.client-id}")
+    private String clientId;
+
+    private static final String iss1 = "accounts.google.com";
+    private static final String iss2 = "https://accounts.google.com";
+    private static final String DELIMITER = "\\.";
+    private static final int HEADER_INDEX = 0;
+
+    public Map<String, String> getParsedHeader(final String identityToken) {
+        try {
+            ObjectMapper mapper = new ObjectMapper();
+            String encodedHeader = identityToken.split(DELIMITER)[HEADER_INDEX];
+            String decodedHeader = new String(Base64Utils.decodeFromUrlSafeString(encodedHeader));
+            return mapper.readValue(decodedHeader, Map.class);
+        } catch (JsonProcessingException e) {
+            throw new UnauthorizedException(Error.INVALID_TOKEN_EXCEPTION, Error.INVALID_TOKEN_EXCEPTION.getMessage());
+        }
+    }
+
+
+    public Claims extractClaims(final String idToken, final PublicKey publicKey) {
+        try {
+            return Jwts.parserBuilder()
+                    .setSigningKey(publicKey)
+                    .build()
+                    .parseClaimsJws(idToken)
+                    .getBody();
+        } catch (ExpiredJwtException e) {
+            throw new UnauthorizedException(Error.TOKEN_TIME_EXPIRED_EXCEPTION,
+                    Error.TOKEN_TIME_EXPIRED_EXCEPTION.getMessage());
+        }
+    }
+
+    public boolean validate(Claims claims) {
+        return (claims.getIssuer().contains(iss1) || claims.getIssuer().contains(iss2)) &&
+                claims.getAudience().equals(clientId);
+    }
 }

--- a/src/main/java/indipage/org/indipage/auth/service/google/GoogleIdTokenProcessor.java
+++ b/src/main/java/indipage/org/indipage/auth/service/google/GoogleIdTokenProcessor.java
@@ -1,0 +1,2 @@
+package indipage.org.indipage.auth.service.google;public class GoogleIdTokenProcessor {
+}

--- a/src/main/java/indipage/org/indipage/auth/service/google/GoogleOAuthClient.java
+++ b/src/main/java/indipage/org/indipage/auth/service/google/GoogleOAuthClient.java
@@ -1,2 +1,42 @@
-package indipage.org.indipage.auth.service.google;public class GoogleOAuthClient {
+package indipage.org.indipage.auth.service.google;
+
+import indipage.org.indipage.auth.dto.OAuthUserResponseDto;
+import indipage.org.indipage.auth.service.OAuthClient;
+import indipage.org.indipage.auth.service.PublicKeyGenerator;
+import indipage.org.indipage.auth.service.JWKs;
+import io.jsonwebtoken.Claims;
+import java.security.PublicKey;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.stereotype.Component;
+import org.springframework.web.bind.annotation.GetMapping;
+
+@Component
+@RequiredArgsConstructor
+public class GoogleOAuthClient implements OAuthClient {
+
+
+    private final GoogleIdTokenProcessor tokenProcessor;
+    private final GooglePublicKeyClient publicKeyClient;
+    private final PublicKeyGenerator publicKeyGenerator;
+
+
+    @Override
+    public OAuthUserResponseDto getUser(final String idToken) {
+        Map<String, String> header = tokenProcessor.getParsedHeader(idToken);
+        JWKs googlePublicKeys = publicKeyClient.getJWKs();
+
+        PublicKey publicKey = publicKeyGenerator.generatePublicKey(header, googlePublicKeys);
+
+        Claims claims = tokenProcessor.extractClaims(idToken, publicKey);
+
+        return OAuthUserResponseDto.generateAppleUserResponseDto(claims.get("email", String.class));
+    }
+
+    @FeignClient(name = "google-public-key-client", url = "https://www.googleapis.com/oauth2/v3")
+    public interface GooglePublicKeyClient {
+        @GetMapping("/certs")
+        JWKs getJWKs();
+    }
 }

--- a/src/main/java/indipage/org/indipage/auth/service/google/GoogleOAuthClient.java
+++ b/src/main/java/indipage/org/indipage/auth/service/google/GoogleOAuthClient.java
@@ -1,0 +1,2 @@
+package indipage.org.indipage.auth.service.google;public class GoogleOAuthClient {
+}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -64,6 +64,8 @@ oauth:
     iss: ${apple-iss}
     client-id: ${apple-client-id}
     nonce: ${apple-nonce}
+  google:
+    client-id: ${google-client-id}
 
 # set1
 ---
@@ -116,12 +118,16 @@ springdoc:
     cache:
       disabled: true
 
+jwt:
+  secret: ${jwt-secret}
+
 oauth:
   apple:
     iss: ${apple-iss}
     client-id: ${apple-client-id}
     nonce: ${apple-nonce}
-
+  google:
+    client-id: ${google-client-id}
 
 # set2
 ---
@@ -160,11 +166,16 @@ cloud:
     stack:
       auto: false
 
+jwt:
+  secret: ${jwt-secret}
+
 oauth:
   apple:
     iss: ${apple-iss}
     client-id: ${apple-client-id}
     nonce: ${apple-nonce}
+  google:
+    client-id: ${google-client-id}
 
 springdoc:
   packages-to-scan: indipage.org.indipage


### PR DESCRIPTION
## 📌 관련 이슈
- closed #113 

## ✨ 구현 내용
- 구글 소셜 로그인 구현 
- application.yaml에 누락된 정보 추가
- JWK 관련 파일 이름 수정

## (선택) 💬 논의 사항
- TokenProccessor이 validate 로직 제외하고 google과 apple이 같아서 추상화 방식에 대해 논의합시당!