### PR TITLE
[ADD] 로그인 & 회원가입 로직 완성

### DIFF
--- a/src/main/java/indipage/org/indipage/api/article/controller/ArticleController.java
+++ b/src/main/java/indipage/org/indipage/api/article/controller/ArticleController.java
@@ -5,12 +5,16 @@ import indipage.org.indipage.api.article.controller.dto.response.ArticleSummaryR
 import indipage.org.indipage.api.article.controller.dto.response.WeeklyArticleResponseDto;
 import indipage.org.indipage.api.article.service.ArticleService;
 import indipage.org.indipage.common.dto.ApiResponse;
+import indipage.org.indipage.config.resolver.UserId;
 import indipage.org.indipage.exception.Success;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
-import org.springframework.web.bind.annotation.*;
-
-import java.util.List;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequestMapping("/article")
@@ -21,20 +25,21 @@ public class ArticleController {
 
     @GetMapping("/{articleId}")
     @ResponseStatus(HttpStatus.OK)
-    public ApiResponse<ArticleResponseDto> readArticle(@PathVariable final Long articleId) {
+    public ApiResponse<ArticleResponseDto> readArticle(@UserId final Long userId, @PathVariable final Long articleId) {
 
         return ApiResponse.success(Success.READ_ARTICLE_SUCCESS, articleService.readArticle(articleId));
     }
 
     @GetMapping
     @ResponseStatus(HttpStatus.OK)
-    public ApiResponse<List<ArticleSummaryResponseDto>> readArticleSummaryList() {
-        return ApiResponse.success(Success.READ_ARTICLE_SUMMARY_LIST_SUCCESS, articleService.readArticleSummaryList(1L));
+    public ApiResponse<List<ArticleSummaryResponseDto>> readArticleSummaryList(@UserId final Long userId) {
+        return ApiResponse.success(Success.READ_ARTICLE_SUMMARY_LIST_SUCCESS,
+                articleService.readArticleSummaryList(userId));
     }
 
     @GetMapping("/weekly")
     @ResponseStatus(HttpStatus.OK)
-    public ApiResponse<WeeklyArticleResponseDto> readWeeklyArticle() {
+    public ApiResponse<WeeklyArticleResponseDto> readWeeklyArticle(@UserId final Long userId) {
         return ApiResponse.success(Success.READ_WEEKLY_ARTICLE_SUCCESS, articleService.readWeeklyArticle());
     }
 }

--- a/src/main/java/indipage/org/indipage/api/auth/controller/AuthController.java
+++ b/src/main/java/indipage/org/indipage/api/auth/controller/AuthController.java
@@ -1,9 +1,14 @@
 package indipage.org.indipage.api.auth.controller;
 
+import indipage.org.indipage.api.auth.dto.request.LoginRequestDto;
 import indipage.org.indipage.auth.service.AuthService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequiredArgsConstructor
@@ -15,10 +20,9 @@ public class AuthController {
     @PostMapping("/login")
     @ResponseStatus(HttpStatus.OK)
     public void login(
-            @RequestParam(value = "platform") final String platform,
-            @RequestParam(value = "token") final String token
+            @RequestBody LoginRequestDto requestDto
     ) {
-        authService.login(platform, token);
+        authService.login(requestDto);
     }
 
 }

--- a/src/main/java/indipage/org/indipage/api/auth/controller/AuthController.java
+++ b/src/main/java/indipage/org/indipage/api/auth/controller/AuthController.java
@@ -1,7 +1,10 @@
 package indipage.org.indipage.api.auth.controller;
 
 import indipage.org.indipage.api.auth.dto.request.LoginRequestDto;
+import indipage.org.indipage.api.auth.dto.response.LoginResponseDto;
 import indipage.org.indipage.auth.service.AuthService;
+import indipage.org.indipage.common.dto.ApiResponse;
+import indipage.org.indipage.exception.Success;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -19,10 +22,10 @@ public class AuthController {
 
     @PostMapping("/login")
     @ResponseStatus(HttpStatus.OK)
-    public void login(
+    public ApiResponse<LoginResponseDto> login(
             @RequestBody LoginRequestDto requestDto
     ) {
-        authService.login(requestDto);
+        return ApiResponse.success(Success.LOGIN_SUCCESS, authService.login(requestDto));
     }
 
 }

--- a/src/main/java/indipage/org/indipage/api/auth/dto/request/LoginRequestDto.java
+++ b/src/main/java/indipage/org/indipage/api/auth/dto/request/LoginRequestDto.java
@@ -1,0 +1,18 @@
+package indipage.org.indipage.api.auth.dto.request;
+
+import indipage.org.indipage.auth.Platform;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@AllArgsConstructor
+public class LoginRequestDto {
+
+    private String accessToken;
+
+    private Platform platform;
+
+}

--- a/src/main/java/indipage/org/indipage/api/auth/dto/response/LoginResponseDto.java
+++ b/src/main/java/indipage/org/indipage/api/auth/dto/response/LoginResponseDto.java
@@ -1,0 +1,20 @@
+package indipage.org.indipage.api.auth.dto.response;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder
+public class LoginResponseDto {
+
+    private String accessToken;
+
+    public static LoginResponseDto of(String accessToken) {
+        return new LoginResponseDto(accessToken);
+    }
+}

--- a/src/main/java/indipage/org/indipage/api/bookmark/controller/BookmarkController.java
+++ b/src/main/java/indipage/org/indipage/api/bookmark/controller/BookmarkController.java
@@ -5,13 +5,19 @@ import indipage.org.indipage.api.bookmark.service.BookmarkService;
 import indipage.org.indipage.api.space.controller.dto.response.SpaceSummaryResponseDto;
 import indipage.org.indipage.api.user.controller.dto.response.IsBookmarkedResponseDto;
 import indipage.org.indipage.common.dto.ApiResponse;
+import indipage.org.indipage.config.resolver.UserId;
 import indipage.org.indipage.exception.Success;
+import java.util.List;
+import javax.validation.constraints.NotNull;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
-import org.springframework.web.bind.annotation.*;
-
-import javax.validation.constraints.NotNull;
-import java.util.List;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequestMapping("/bookmark")
@@ -23,57 +29,60 @@ public class BookmarkController {
 
     @GetMapping("/article/{articleId}")
     @ResponseStatus(HttpStatus.OK)
-    public ApiResponse<IsBookmarkedResponseDto> readIsArticleBookMarked(@PathVariable Long articleId) {
+    public ApiResponse<IsBookmarkedResponseDto> readIsArticleBookMarked(@UserId final Long userId,
+                                                                        @PathVariable Long articleId) {
         return ApiResponse.success(Success.READ_IS_ARTICLE_BOOKMARKED_SUCCESS,
-                bookmarkService.readArticleBookmark(1L, articleId));
+                bookmarkService.readArticleBookmark(userId, articleId));
     }
 
     @PostMapping("/article/{articleId}")
     @ResponseStatus(HttpStatus.CREATED)
-    public ApiResponse createArticleBookmark(@PathVariable Long articleId) {
-        bookmarkService.createArticleBookmark(1L, articleId);
+    public ApiResponse createArticleBookmark(@UserId final Long userId, @PathVariable Long articleId) {
+        bookmarkService.createArticleBookmark(userId, articleId);
         return ApiResponse.success(Success.CREATE_ARTICLE_BOOKMARK_SUCCESS);
     }
 
     @DeleteMapping("/article/{articleId}")
     @ResponseStatus(HttpStatus.OK)
-    public ApiResponse deleteArticleBookmark(@PathVariable Long articleId) {
-        bookmarkService.deleteArticleBookmark(1L, articleId);
+    public ApiResponse deleteArticleBookmark(@UserId final Long userId, @PathVariable Long articleId) {
+        bookmarkService.deleteArticleBookmark(userId, articleId);
         return ApiResponse.success(Success.DELETE_ARTICLE_BOOKMARK_SUCCESS);
     }
 
     @GetMapping("/space/{spaceId}")
     @ResponseStatus(HttpStatus.OK)
-    public ApiResponse<IsBookmarkedResponseDto> readIsSpaceBookmarked(@PathVariable Long spaceId) {
+    public ApiResponse<IsBookmarkedResponseDto> readIsSpaceBookmarked(@UserId final Long userId,
+                                                                      @PathVariable Long spaceId) {
         return ApiResponse.success(Success.READ_IS_SPACE_BOOKMARKED_SUCCESS,
-                bookmarkService.readSpaceBookmark(1L, spaceId));
+                bookmarkService.readSpaceBookmark(userId, spaceId));
     }
 
     @PostMapping("/space/{spaceId}")
     @ResponseStatus(HttpStatus.CREATED)
-    public ApiResponse createSpaceBookmark(@PathVariable @NotNull Long spaceId) {
-        bookmarkService.createSpaceBookmark(1L, spaceId);
+    public ApiResponse createSpaceBookmark(@UserId final Long userId, @PathVariable @NotNull Long spaceId) {
+        bookmarkService.createSpaceBookmark(userId, spaceId);
         return ApiResponse.success(Success.CREATE_SPACE_BOOKMARK_SUCCESS);
     }
 
     @DeleteMapping("/space/{spaceId}")
     @ResponseStatus(HttpStatus.OK)
-    public ApiResponse deleteSpaceBookmark(@PathVariable Long spaceId) {
-        bookmarkService.deleteSpaceBookmark(1L, spaceId);
+    public ApiResponse deleteSpaceBookmark(@UserId final Long userId, @PathVariable Long spaceId) {
+        bookmarkService.deleteSpaceBookmark(userId, spaceId);
         return ApiResponse.success(Success.DELETE_SPACE_BOOKMARK_SUCCESS);
     }
 
     @GetMapping("/article")
     @ResponseStatus(HttpStatus.OK)
-    public ApiResponse<List<ArticleSummaryResponseDto>> readArticleBookmarkList() {
+    public ApiResponse<List<ArticleSummaryResponseDto>> readArticleBookmarkList(@UserId final Long userId) {
         return ApiResponse.success(Success.READ_ARTICLE_BOOKMARK_LIST_SUCCESS,
-                bookmarkService.readArticleBookmarkList(1L));
+                bookmarkService.readArticleBookmarkList(userId));
     }
 
     @GetMapping("/space")
     @ResponseStatus(HttpStatus.OK)
-    public ApiResponse<List<SpaceSummaryResponseDto>> readSpaceBookmarkList() {
-        return ApiResponse.success(Success.READ_SPACE_BOOKMARK_LIST_SUCCESS, bookmarkService.readSpaceBookmarkList(1L));
+    public ApiResponse<List<SpaceSummaryResponseDto>> readSpaceBookmarkList(@UserId final Long userId) {
+        return ApiResponse.success(Success.READ_SPACE_BOOKMARK_LIST_SUCCESS,
+                bookmarkService.readSpaceBookmarkList(userId));
     }
 
 }

--- a/src/main/java/indipage/org/indipage/api/space/controller/SpaceController.java
+++ b/src/main/java/indipage/org/indipage/api/space/controller/SpaceController.java
@@ -3,6 +3,7 @@ package indipage.org.indipage.api.space.controller;
 import indipage.org.indipage.api.space.controller.dto.response.*;
 import indipage.org.indipage.api.space.service.SpaceService;
 import indipage.org.indipage.common.dto.ApiResponse;
+import indipage.org.indipage.config.resolver.UserId;
 import indipage.org.indipage.exception.Success;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -20,48 +21,48 @@ public class SpaceController {
 
     @GetMapping("/{spaceId}")
     @ResponseStatus(HttpStatus.OK)
-    public ApiResponse<SpaceDto> readSpace(@PathVariable final Long spaceId) {
+    public ApiResponse<SpaceDto> readSpace(@UserId final Long userId, @PathVariable final Long spaceId) {
 
         return ApiResponse.success(Success.READ_SPACE_SUCCESS, spaceService.readSpace(spaceId));
     }
 
     @GetMapping("/{spaceId}/book")
     @ResponseStatus(HttpStatus.OK)
-    public ApiResponse<List<BookRecommendationResponseDto>> readBookRecommendation(@PathVariable final Long spaceId) {
+    public ApiResponse<List<BookRecommendationResponseDto>> readBookRecommendation(@UserId final Long userId, @PathVariable final Long spaceId) {
         return ApiResponse.success(Success.READ_BOOK_RECOMMENDATION_SUCCESS,
                 spaceService.readBookRecommendation(spaceId));
     }
 
     @GetMapping("/{spaceId}/follow")
     @ResponseStatus(HttpStatus.OK)
-    public ApiResponse<FollowSpaceRelationResponseDto> readFollowSpace(@PathVariable final Long spaceId) {
+    public ApiResponse<FollowSpaceRelationResponseDto> readFollowSpace(@UserId final Long userId, @PathVariable final Long spaceId) {
         return ApiResponse.success(Success.READ_FOLLOW_SPACE_SUCCESS,
-                spaceService.readFollowSpace(1L, spaceId));
+                spaceService.readFollowSpace(userId, spaceId));
     }
 
     @PostMapping("/{spaceId}/follow")
     @ResponseStatus(HttpStatus.CREATED)
-    public ApiResponse createFollowSpace(@PathVariable final Long spaceId) {
-        spaceService.createFollowSpace(1L, spaceId);
+    public ApiResponse createFollowSpace(@UserId final Long userId, @PathVariable final Long spaceId) {
+        spaceService.createFollowSpace(userId, spaceId);
         return ApiResponse.success(Success.CREATE_FOLLOW_SPACE_SUCCESS);
     }
 
     @GetMapping("/{spaceId}/article")
     @ResponseStatus(HttpStatus.OK)
-    public ApiResponse<ArticleOfSpaceResponseDto> readArticleOfSpace(@PathVariable final Long spaceId) {
+    public ApiResponse<ArticleOfSpaceResponseDto> readArticleOfSpace(@UserId final Long userId, @PathVariable final Long spaceId) {
         return ApiResponse.success(Success.READ_ARTICLE_OF_SPACE_SUCCESS, spaceService.readArticleOfSpace(spaceId));
     }
 
     @PatchMapping("/{spaceId}/visit")
     @ResponseStatus(HttpStatus.OK)
-    public ApiResponse<SpaceVisitResponseDto> updateVisit(@PathVariable final Long spaceId) {
+    public ApiResponse<SpaceVisitResponseDto> updateVisit(@UserId final Long userId, @PathVariable final Long spaceId) {
 
-        return ApiResponse.success(Success.UPDATE_VISIT_SUCCESS, spaceService.visit(1L, spaceId));
+        return ApiResponse.success(Success.UPDATE_VISIT_SUCCESS, spaceService.visit(userId, spaceId));
     }
 
     @GetMapping("/list")
     @ResponseStatus(HttpStatus.OK)
-    public ApiResponse<List<SpaceSearchResponseDto>> searchWithAddress(@RequestParam(value = "keyword") Optional<String> searchWord) {
+    public ApiResponse<List<SpaceSearchResponseDto>> searchWithAddress(@RequestParam(value = "keyword") Optional<String> searchWord, @UserId final Long userId) {
         return ApiResponse.success(Success.SEARCH_SPACE_SUCCESS, spaceService.searchSpace(searchWord));
     }
 }

--- a/src/main/java/indipage/org/indipage/api/user/controller/UserController.java
+++ b/src/main/java/indipage/org/indipage/api/user/controller/UserController.java
@@ -7,12 +7,18 @@ import indipage.org.indipage.api.user.controller.dto.response.HasReceivedTicketR
 import indipage.org.indipage.api.user.controller.dto.response.UserDto;
 import indipage.org.indipage.api.user.service.UserService;
 import indipage.org.indipage.common.dto.ApiResponse;
+import indipage.org.indipage.config.resolver.UserId;
 import indipage.org.indipage.exception.Success;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
-import org.springframework.web.bind.annotation.*;
-
-import java.util.List;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequestMapping("/user")
@@ -22,47 +28,49 @@ public class UserController {
 
     @GetMapping
     @ResponseStatus(HttpStatus.OK)
-    public ApiResponse<UserDto> readUser() {
-        return ApiResponse.success(Success.READ_USER_SUCCESS, userService.readUser(1L));
+    public ApiResponse<UserDto> readUser(@UserId final Long userId) {
+        return ApiResponse.success(Success.READ_USER_SUCCESS, userService.readUser(userId));
     }
 
     @GetMapping("/ticket/{spaceId}")
     @ResponseStatus(HttpStatus.OK)
-    public ApiResponse<HasReceivedTicketResponseDto> readIfUserHasReceivedTicket(@PathVariable final Long spaceId) {
+    public ApiResponse<HasReceivedTicketResponseDto> readIfUserHasReceivedTicket(@UserId final Long userId,
+                                                                                 @PathVariable final Long spaceId) {
         return ApiResponse.success(Success.READ_IF_USER_HAS_RECEIVED_TICKET_SUCCESS,
-                userService.readIfUserHasReceivedTicket(1L, spaceId));
+                userService.readIfUserHasReceivedTicket(userId, spaceId));
     }
 
     @PostMapping("/ticket/{spaceId}")
     @ResponseStatus(HttpStatus.CREATED)
-    public ApiResponse createReceiveTicket(@PathVariable final Long spaceId) {
-        userService.receiveTicket(1L, spaceId);
+    public ApiResponse createReceiveTicket(@UserId final Long userId, @PathVariable final Long spaceId) {
+        userService.receiveTicket(userId, spaceId);
         return ApiResponse.success(Success.CREATE_RECEIVE_TICKET_SUCCESS);
     }
 
     @PatchMapping("/weekly/slide")
     @ResponseStatus(HttpStatus.OK)
-    public ApiResponse UpdateSlideAt() {
-        userService.updateSlideAt(1L);
+    public ApiResponse UpdateSlideAt(@UserId final Long userId) {
+        userService.updateSlideAt(userId);
         return ApiResponse.success(Success.UPDATE_SLIDE_AT_SUCCESS);
     }
 
 
     @GetMapping("/ticket")
     @ResponseStatus(HttpStatus.OK)
-    public ApiResponse<List<ReceivedTicketResponseDto>> readReceivedTicket() {
-        return ApiResponse.success(Success.READ_RECEIVED_TICKET_SUCCESS, userService.readReceivedTicketList(1L));
+    public ApiResponse<List<ReceivedTicketResponseDto>> readReceivedTicket(@UserId final Long userId) {
+        return ApiResponse.success(Success.READ_RECEIVED_TICKET_SUCCESS, userService.readReceivedTicketList(userId));
     }
 
     @GetMapping("/card")
     @ResponseStatus(HttpStatus.OK)
-    public ApiResponse<List<ReceivedCardResponseDto>> readReceivedCard() {
-        return ApiResponse.success(Success.READ_RECEIVED_CARD_SUCCESS, userService.readReceivedCardList(1L));
+    public ApiResponse<List<ReceivedCardResponseDto>> readReceivedCard(@UserId final Long userId) {
+        return ApiResponse.success(Success.READ_RECEIVED_CARD_SUCCESS, userService.readReceivedCardList(userId));
     }
 
     @GetMapping("/weekly/slide")
     @ResponseStatus(HttpStatus.OK)
-    public ApiResponse<HasSlideWeeklyArticleResponseDto> readHasSlideWeeklyArticle() {
-        return ApiResponse.success(Success.READ_HAS_SLIDE_WEEKLY_ARTICLE_SUCCESS, userService.readHasSlideWeeklyArticle(1L));
+    public ApiResponse<HasSlideWeeklyArticleResponseDto> readHasSlideWeeklyArticle(@UserId final Long userId) {
+        return ApiResponse.success(Success.READ_HAS_SLIDE_WEEKLY_ARTICLE_SUCCESS,
+                userService.readHasSlideWeeklyArticle(userId));
     }
 }

--- a/src/main/java/indipage/org/indipage/api/user/service/UserService.java
+++ b/src/main/java/indipage/org/indipage/api/user/service/UserService.java
@@ -6,18 +6,26 @@ import indipage.org.indipage.api.ticket.controller.dto.response.ReceivedTicketRe
 import indipage.org.indipage.api.ticket.service.TicketService;
 import indipage.org.indipage.api.user.controller.dto.response.HasReceivedTicketResponseDto;
 import indipage.org.indipage.api.user.controller.dto.response.UserDto;
-import indipage.org.indipage.domain.*;
+import indipage.org.indipage.auth.Platform;
+import indipage.org.indipage.domain.Article;
+import indipage.org.indipage.domain.ArticleRepository;
+import indipage.org.indipage.domain.InviteSpaceRelationRepository;
 import indipage.org.indipage.domain.Relation.InviteSpaceRelation;
+import indipage.org.indipage.domain.Space;
+import indipage.org.indipage.domain.SpaceRepository;
+import indipage.org.indipage.domain.Ticket;
+import indipage.org.indipage.domain.User;
+import indipage.org.indipage.domain.UserRepository;
 import indipage.org.indipage.exception.Error;
 import indipage.org.indipage.exception.model.ConflictException;
 import indipage.org.indipage.exception.model.NotFoundException;
-import lombok.RequiredArgsConstructor;
-import org.springframework.stereotype.Service;
-
-import javax.transaction.Transactional;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
+import javax.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
 
 @Service
 @RequiredArgsConstructor

--- a/src/main/java/indipage/org/indipage/auth/JwtProvider.java
+++ b/src/main/java/indipage/org/indipage/auth/JwtProvider.java
@@ -7,14 +7,13 @@ import io.jsonwebtoken.ExpiredJwtException;
 import io.jsonwebtoken.Header;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.security.Keys;
-import org.springframework.beans.factory.annotation.Value;
-import org.springframework.stereotype.Component;
-
-import javax.annotation.PostConstruct;
 import java.nio.charset.StandardCharsets;
 import java.security.Key;
 import java.util.Base64;
 import java.util.Date;
+import javax.annotation.PostConstruct;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
 
 @Component
 public class JwtProvider {
@@ -27,7 +26,7 @@ public class JwtProvider {
         jwtSecret = Base64.getEncoder().encodeToString(jwtSecret.getBytes(StandardCharsets.UTF_8));
     }
 
-    public String issuedToken(String userId) {
+    public String issuedToken(Long userId) {
         final Date now = new Date();
 
         final Claims claims = Jwts.claims().setSubject("access_token").setIssuedAt(now)

--- a/src/main/java/indipage/org/indipage/auth/dto/OAuthUserResponseDto.java
+++ b/src/main/java/indipage/org/indipage/auth/dto/OAuthUserResponseDto.java
@@ -4,9 +4,11 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Builder
+@Getter
 @JsonIgnoreProperties(ignoreUnknown = true)
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)

--- a/src/main/java/indipage/org/indipage/auth/service/AuthService.java
+++ b/src/main/java/indipage/org/indipage/auth/service/AuthService.java
@@ -20,6 +20,7 @@ public class AuthService {
     private final UserRepository userRepository;
     private final JwtProvider jwtProvider;
 
+    @Transactional
     public LoginResponseDto login(final LoginRequestDto requestDto) {
         OAuthClient client = clientProvider.getClient(requestDto.getPlatform());
         OAuthUserResponseDto responseDto = client.getUser(requestDto.getAccessToken());
@@ -28,14 +29,10 @@ public class AuthService {
                 .map(user -> jwtProvider.issuedToken((user.getId())))
                 .orElse(singUp(requestDto.getPlatform(), responseDto));
 
-        if (accessToken.isEmpty()) {
-            userRepository.save(
-                    User.of(responseDto.getEmail(), responseDto.getName(), requestDto.getPlatform()));
-        }
-
         return LoginResponseDto.of(accessToken);
     }
 
+    @Transactional
     public String singUp(final Platform platform, final OAuthUserResponseDto responseDto) {
         User user = userRepository.save(
                 User.of(responseDto.getEmail(), responseDto.getName(), platform));

--- a/src/main/java/indipage/org/indipage/auth/service/AuthService.java
+++ b/src/main/java/indipage/org/indipage/auth/service/AuthService.java
@@ -27,13 +27,13 @@ public class AuthService {
 
         String accessToken = userRepository.findByEmailAndName(responseDto.getEmail(), responseDto.getName())
                 .map(user -> jwtProvider.issuedToken((user.getId())))
-                .orElse(singUp(requestDto.getPlatform(), responseDto));
+                .orElseGet(() -> signUp(requestDto.getPlatform(), responseDto));
 
         return LoginResponseDto.of(accessToken);
     }
 
     @Transactional
-    public String singUp(final Platform platform, final OAuthUserResponseDto responseDto) {
+    public String signUp(final Platform platform, final OAuthUserResponseDto responseDto) {
         User user = userRepository.save(
                 User.of(responseDto.getEmail(), responseDto.getName(), platform));
 

--- a/src/main/java/indipage/org/indipage/auth/service/AuthService.java
+++ b/src/main/java/indipage/org/indipage/auth/service/AuthService.java
@@ -1,7 +1,12 @@
 package indipage.org.indipage.auth.service;
 
+import indipage.org.indipage.api.auth.dto.request.LoginRequestDto;
+import indipage.org.indipage.api.auth.dto.response.LoginResponseDto;
 import indipage.org.indipage.auth.JwtProvider;
+import indipage.org.indipage.auth.Platform;
 import indipage.org.indipage.auth.dto.OAuthUserResponseDto;
+import indipage.org.indipage.domain.User;
+import indipage.org.indipage.domain.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -12,13 +17,30 @@ import org.springframework.transaction.annotation.Transactional;
 public class AuthService {
 
     private final OAuthClientProvider clientProvider;
+    private final UserRepository userRepository;
     private final JwtProvider jwtProvider;
 
-    public void login(final String platform, final String accessToken) {
-        OAuthClient client = clientProvider.getClient(platform);
-        OAuthUserResponseDto oAuthUserResponseDto = client.getUser(accessToken);
+    public LoginResponseDto login(final LoginRequestDto requestDto) {
+        OAuthClient client = clientProvider.getClient(requestDto.getPlatform());
+        OAuthUserResponseDto responseDto = client.getUser(requestDto.getAccessToken());
 
-        // TODO: 회원가입, 로그인 및 토큰 반환 기능 구현
+        String accessToken = userRepository.findByEmailAndName(responseDto.getEmail(), responseDto.getName())
+                .map(user -> jwtProvider.issuedToken((user.getId())))
+                .orElse(singUp(requestDto.getPlatform(), responseDto));
+
+        if (accessToken.isEmpty()) {
+            userRepository.save(
+                    User.of(responseDto.getEmail(), responseDto.getName(), requestDto.getPlatform()));
+        }
+
+        return LoginResponseDto.of(accessToken);
+    }
+
+    public String singUp(final Platform platform, final OAuthUserResponseDto responseDto) {
+        User user = userRepository.save(
+                User.of(responseDto.getEmail(), responseDto.getName(), platform));
+
+        return jwtProvider.issuedToken(user.getId());
     }
 
 }

--- a/src/main/java/indipage/org/indipage/auth/service/AuthService.java
+++ b/src/main/java/indipage/org/indipage/auth/service/AuthService.java
@@ -26,7 +26,7 @@ public class AuthService {
         OAuthUserResponseDto responseDto = client.getUser(requestDto.getAccessToken());
 
         String accessToken = userRepository.findByEmail(responseDto.getEmail())
-                .map(user -> jwtProvider.issuedToken((user.getId())))
+                .map(user -> jwtProvider.issuedToken((user.getId()).toString()))
                 .orElseGet(() -> signUp(requestDto.getPlatform(), responseDto));
 
         return LoginResponseDto.of(accessToken);
@@ -37,7 +37,7 @@ public class AuthService {
         User user = userRepository.save(
                 User.of(responseDto.getEmail(), responseDto.getName(), platform));
 
-        return jwtProvider.issuedToken(user.getId());
+        return jwtProvider.issuedToken(user.getId().toString());
     }
 
 }

--- a/src/main/java/indipage/org/indipage/auth/service/AuthService.java
+++ b/src/main/java/indipage/org/indipage/auth/service/AuthService.java
@@ -25,7 +25,7 @@ public class AuthService {
         OAuthClient client = clientProvider.getClient(requestDto.getPlatform());
         OAuthUserResponseDto responseDto = client.getUser(requestDto.getAccessToken());
 
-        String accessToken = userRepository.findByEmailAndName(responseDto.getEmail(), responseDto.getName())
+        String accessToken = userRepository.findByEmail(responseDto.getEmail())
                 .map(user -> jwtProvider.issuedToken((user.getId())))
                 .orElseGet(() -> signUp(requestDto.getPlatform(), responseDto));
 

--- a/src/main/java/indipage/org/indipage/auth/service/JWKs.java
+++ b/src/main/java/indipage/org/indipage/auth/service/JWKs.java
@@ -1,12 +1,11 @@
 package indipage.org.indipage.auth.service;
 
+import java.util.List;
+import java.util.Optional;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-
-import java.util.List;
-import java.util.Optional;
 
 
 @Getter
@@ -34,7 +33,7 @@ public class JWKs {
                 .filter(k -> k.getAlg().equals(alg) && k.getKid().equals(kid))
                 .findFirst();
 
-        return matchingKey.orElseThrow(() -> new IllegalArgumentException("Apple JWT 값의 alg, kid 정보가 올바르지 않습니다."));
+        return matchingKey.orElseThrow(() -> new IllegalArgumentException("JWT 값의 alg, kid 정보가 올바르지 않습니다."));
     }
 
 }

--- a/src/main/java/indipage/org/indipage/auth/service/OAuthClientProvider.java
+++ b/src/main/java/indipage/org/indipage/auth/service/OAuthClientProvider.java
@@ -25,7 +25,7 @@ public class OAuthClientProvider {
         oAuthClientMap.put(Platform.GOOGLE, googleOAuthClient);
     }
 
-    public OAuthClient getClient(final String platformName) {
-        return oAuthClientMap.get(Platform.valueOf(platformName));
+    public OAuthClient getClient(final Platform platformName) {
+        return oAuthClientMap.get(platformName);
     }
 }

--- a/src/main/java/indipage/org/indipage/auth/service/google/GoogleOAuthClient.java
+++ b/src/main/java/indipage/org/indipage/auth/service/google/GoogleOAuthClient.java
@@ -29,7 +29,7 @@ public class GoogleOAuthClient implements OAuthClient {
         PublicKey publicKey = publicKeyGenerator.generatePublicKey(header, googlePublicKeys);
 
         Claims claims = tokenProcessor.extractClaims(idToken, publicKey);
-
+        tokenProcessor.validate(claims);
         return OAuthUserResponseDto.generateAppleUserResponseDto(claims.get("email", String.class));
     }
 

--- a/src/main/java/indipage/org/indipage/config/WebConfig.java
+++ b/src/main/java/indipage/org/indipage/config/WebConfig.java
@@ -1,2 +1,20 @@
-package indipage.org.indipage.config;public class WebConfig {
+package indipage.org.indipage.config;
+
+import indipage.org.indipage.config.resolver.UserIdResolver;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@RequiredArgsConstructor
+@Configuration
+public class WebConfig implements WebMvcConfigurer {
+
+    private final UserIdResolver userIdResolver;
+
+    @Override
+    public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
+        resolvers.add(userIdResolver);
+    }
 }

--- a/src/main/java/indipage/org/indipage/config/WebConfig.java
+++ b/src/main/java/indipage/org/indipage/config/WebConfig.java
@@ -1,0 +1,2 @@
+package indipage.org.indipage.config;public class WebConfig {
+}

--- a/src/main/java/indipage/org/indipage/config/resolver/UserIdResolver.java
+++ b/src/main/java/indipage/org/indipage/config/resolver/UserIdResolver.java
@@ -27,11 +27,6 @@ public class UserIdResolver implements HandlerMethodArgumentResolver {
         final HttpServletRequest request = (HttpServletRequest) webRequest.getNativeRequest();
         final String token = request.getHeader("Authorization");
 
-        if (!jwtProvider.verifyToken(token)) {
-            throw new RuntimeException(
-                    String.format("USER_ID를 가져오지 못했습니다. (%s - %s)", parameter.getClass(), parameter.getMethod()));
-        }
-
         // 유저 아이디 반환
         final String tokenContents = jwtProvider.getJwtContents(token);
         try {

--- a/src/main/java/indipage/org/indipage/domain/User.java
+++ b/src/main/java/indipage/org/indipage/domain/User.java
@@ -3,14 +3,21 @@ package indipage.org.indipage.domain;
 import indipage.org.indipage.auth.Platform;
 import indipage.org.indipage.domain.Relation.ArticleBookmarkRelation;
 import indipage.org.indipage.domain.Relation.SpaceBookmarkRelation;
-import lombok.AccessLevel;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-
-import javax.persistence.*;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
+import javax.persistence.FetchType;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.OneToMany;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Entity
 @Getter
@@ -41,5 +48,15 @@ public class User extends CreatedTimeBaseEntity {
 
     public void updateSlideAt() {
         this.slideAt = LocalDateTime.now();
+    }
+
+    private User(String email, String name, Platform platform) {
+        this.email = email;
+        this.name = name;
+        this.platform = platform;
+    }
+
+    public static User of(String email, String name, Platform platform) {
+        return new User(email, name, platform);
     }
 }

--- a/src/main/java/indipage/org/indipage/domain/UserRepository.java
+++ b/src/main/java/indipage/org/indipage/domain/UserRepository.java
@@ -6,7 +6,7 @@ import org.springframework.data.repository.Repository;
 public interface UserRepository extends Repository<User, Long> {
     Optional<User> findById(Long id);
 
-    Optional<User> findByEmailAndName(String email, String name);
+    Optional<User> findByEmail(String email);
 
     User save(User user);
 }

--- a/src/main/java/indipage/org/indipage/domain/UserRepository.java
+++ b/src/main/java/indipage/org/indipage/domain/UserRepository.java
@@ -1,9 +1,12 @@
 package indipage.org.indipage.domain;
 
-import org.springframework.data.repository.Repository;
-
 import java.util.Optional;
+import org.springframework.data.repository.Repository;
 
 public interface UserRepository extends Repository<User, Long> {
     Optional<User> findById(Long id);
+
+    Optional<User> findByEmailAndName(String email, String name);
+
+    User save(User user);
 }


### PR DESCRIPTION
## 📌 관련 이슈
- closed #115 

## ✨ 구현 내용
- **AuthController**
    - 변경
        - 필요한 정보 request param -> request body로 받기 (LoginRequestDto 생성)
            - 요청시 중요한 값은 url이 아니라 body로 보내는 것이 맞다고 생각해서 바꿨습니다
- **OAuthClientProvider**
    - 변경
        - getClient 매개변수 타입 String -> Platform으로 변경
-  **JwtProvider**
    - 변경
        - issuedToken 메서드 매개변수 타입 String -> Long으로 변경
        - 다시 String으로 변경
            - token에서 claim 가져올 때 Long으로 못가져오기 때문에 Long으로 생성시 문제 발생
        - verify(token) 메서드 private으로 변경
            - 내부 메서드에서만 사용하도록 변경함.
            - 외부에서는 getJwtContent()만 불러도 내부적으로 verify하도록

- **OAuthUserResponseDto**
    - 생성
        - Getter 추가

- **AuthService**
    - 변경 
        - login 메서드 응답 값 LoginResponseDto로 변경
        - login 메서드 매개변수 LoginRequestDto로 변경
    - 생성
        - 기존 유저면 accessToken 만듣어서 리턴
        - 기존 유저 아니면 회원가입(signUp 메서드 호출)하고 accessToken 만들어서 리턴


Google Login은 정상 작동 테스트 완료!

## (선택) 💬 논의 사항
- RequestBody에 지원하지 않는 platform을 입력받 았을 때 처리를 어떻게 할지 논의 필요
- @JsonCreate로 생성자 생성해서 하려했는데 어짜피 여기서 throw한 에러를 messageconverter가 받아서 소용이 없음 힝

