### PR TITLE
[FIX] 애플 로그인 시 유효성 검사에서 필요하지 않은 로직을 삭제한다.

### DIFF
--- a/src/main/java/indipage/org/indipage/auth/service/apple/AppleIdentityTokenProcessor.java
+++ b/src/main/java/indipage/org/indipage/auth/service/apple/AppleIdentityTokenProcessor.java
@@ -11,17 +11,13 @@ import org.springframework.stereotype.Component;
 public class AppleIdentityTokenProcessor extends IdentityTokenProcessor {
 
     private final EncryptUtils encryptUtils;
-
     private final AppleTokenValidationContext validationContext;
-
-    private static final String NONCE_KEY = "nonce";
     private static final String iss = "https://appleid.apple.com";
 
 
     public boolean validateIdentityToken(Claims claims) {
         return claims.getIssuer().contains(iss) &&
-                claims.getAudience().equals(validationContext.getClientId()) &&
-                encryptUtils.hashWithSHA256(claims.get(NONCE_KEY, String.class)).equals(validationContext.getNonce());
+                claims.getAudience().equals(validationContext.getClientId());
     }
 
 }

--- a/src/main/java/indipage/org/indipage/auth/service/apple/AppleOAuthClient.java
+++ b/src/main/java/indipage/org/indipage/auth/service/apple/AppleOAuthClient.java
@@ -4,6 +4,8 @@ import indipage.org.indipage.auth.dto.OAuthUserResponseDto;
 import indipage.org.indipage.auth.service.JWKs;
 import indipage.org.indipage.auth.service.OAuthClient;
 import indipage.org.indipage.auth.service.PublicKeyGenerator;
+import indipage.org.indipage.exception.Error;
+import indipage.org.indipage.exception.model.UnauthorizedException;
 import io.jsonwebtoken.Claims;
 import lombok.RequiredArgsConstructor;
 import org.springframework.cloud.openfeign.FeignClient;
@@ -30,7 +32,9 @@ public class AppleOAuthClient implements OAuthClient {
 
         Claims claims = identityTokenProcessor.extractClaims(accessToken, publicKey);
 
-        identityTokenProcessor.validateIdentityToken(claims);
+        if (!identityTokenProcessor.validateIdentityToken(claims)) {
+            throw new UnauthorizedException(Error.INVALID_TOKEN_EXCEPTION, Error.INVALID_TOKEN_EXCEPTION.getMessage());
+        }
 
         return OAuthUserResponseDto.generateAppleUserResponseDto(claims.get("email", String.class));
     }


### PR DESCRIPTION
## 📌 관련 이슈
- closed #119

## ✨ 구현 내용
- nonce 를 이용하여 유효성을 검사하는 로직을 삭제한다.
